### PR TITLE
Changes for better Python interop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ latex/
 *.app
 LOG.txt
 KarstNSim/build/*
+
+simulation_times.txt

--- a/Input_files/1_base/instructions.txt
+++ b/Input_files/1_base/instructions.txt
@@ -161,4 +161,5 @@ multiply_costs: false
 create_vset_sampling: true
 create_nghb_graph: false
 create_nghb_graph_property: false
+create_solved_connectivity_matrix: true
 create_grid: false

--- a/KarstNSim/CMakeLists.txt
+++ b/KarstNSim/CMakeLists.txt
@@ -38,6 +38,7 @@ set(KARSTNSIM_INCLUDES
     include/KarstNSim/run_code.h 
     include/KarstNSim/parse_inputs.h 
     include/KarstNSim/nanoflann.hpp
+    include/KarstNSim/models/results.h
 )
 
 include_directories("include")

--- a/KarstNSim/CMakeLists.txt
+++ b/KarstNSim/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.8...3.28)
 project(KarstNSim VERSION 1.0 LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 14 CACHE STRING "The C++ standard to use")
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/KarstNSim/CMakeLists.txt
+++ b/KarstNSim/CMakeLists.txt
@@ -44,8 +44,3 @@ set(KARSTNSIM_INCLUDES
 include_directories("include")
 
 add_executable(karstnsim ${KARSTNSIM_SOURCES} ${KARSTNSIM_INCLUDES})
-
-# Linux GCC still needs explicit link with stdc++fs when using std::experimental::filesystem
-if (UNIX AND NOT APPLE)
-    target_link_libraries(karstnsim PRIVATE stdc++fs)
-endif()

--- a/KarstNSim/include/KarstNSim/basics.h
+++ b/KarstNSim/include/KarstNSim/basics.h
@@ -395,8 +395,8 @@ namespace KarstNSim {
 		const Vector3& get_node(const int& i) const; //!< Returns the point (node) at index i.
 		Vector3 nearest(Vector3 p1, Vector3 p2, Vector3 ptest); //!< Finds the nearest point between two points p1 and p2 to the test point ptest.
 		Vector3 nearest(Vector3 p1, Vector3 p2, Vector3 p3, Vector3 ptest); //!< Finds the nearest point among three points p1, p2, and p3 to the test point ptest.
-		Vector3 get_boundbox_min(); //!< Returns the minimum bound of the surface (bounding box).
-		Vector3 get_boundbox_max(); //!< Returns the maximum bound of the surface (bounding box).
+		const Vector3 get_boundbox_min() const; //!< Returns the minimum bound of the surface (bounding box).
+		const Vector3 get_boundbox_max() const; //!< Returns the maximum bound of the surface (bounding box).
 		float get_circumradii(const int& i); //!< Returns the circumradius of the triangle at index i.
 		Vector3 get_trgl_center(const int& trgl_idx); //!< Returns the center of the triangle at index trgl_idx.
 		PointCloud get_centers_cloud(int dim) const; //!< Returns a PointCloud of the centers of the triangles in the surface.
@@ -606,7 +606,7 @@ namespace KarstNSim {
 	\brief Returns the minimum bound of the surface (bounding box).
 	\return The minimum bound vector.
 	*/
-	inline Vector3 Surface::get_boundbox_min() {
+	inline const Vector3 Surface::get_boundbox_min() const {
 		return b_min_;
 	}
 
@@ -614,7 +614,7 @@ namespace KarstNSim {
 	\brief Returns the maximum bound of the surface (bounding box).
 	\return The maximum bound vector.
 	*/
-	inline Vector3 Surface::get_boundbox_max() {
+	inline const Vector3 Surface::get_boundbox_max() const {
 		return b_max_;
 	}
 
@@ -1002,7 +1002,7 @@ namespace KarstNSim {
 		 * \param v The transformed v-coordinate.
 		 * \param w The transformed w-coordinate.
 		 */
-		void xyz2uvw(const Vector3& pt, int &u, int &v, int &w);
+		void xyz2uvw(const Vector3& pt, int &u, int &v, int &w) const;
 
 		/**
 		 * \brief Transforms a point from world coordinates to the uvw coordinate system, with bounds checking.
@@ -1011,7 +1011,7 @@ namespace KarstNSim {
 		 * \param v1 The transformed v-coordinate.
 		 * \param w1 The transformed w-coordinate.
 		 */
-		void xyz2uvw_with_limits_conditions(const Vector3& pt, int &u1, int &v1, int &w1);
+		void xyz2uvw_with_limits_conditions(const Vector3& pt, int &u1, int &v1, int &w1) const;
 
 		/**
 		 * \brief Converts the cell coordinates (u, v, w) to a 1D index.
@@ -1228,7 +1228,7 @@ namespace KarstNSim {
 		return end;
 	}
 
-	inline void Box::xyz2uvw(const Vector3& pt, int &up, int &vp, int &wp) {
+	inline void Box::xyz2uvw(const Vector3& pt, int &up, int &vp, int &wp) const {
 
 		// 1: normalize vector
 
@@ -1269,7 +1269,7 @@ namespace KarstNSim {
 		return point;
 	}
 
-	inline void Box::xyz2uvw_with_limits_conditions(const Vector3& pt, int &u1, int &v1, int &w1) {
+	inline void Box::xyz2uvw_with_limits_conditions(const Vector3& pt, int &u1, int &v1, int &w1) const {
 		xyz2uvw(pt, u1, v1, w1);
 		if (u1 < 0) {
 			u1 = 0;

--- a/KarstNSim/include/KarstNSim/basics.h
+++ b/KarstNSim/include/KarstNSim/basics.h
@@ -387,11 +387,10 @@ namespace KarstNSim {
 	public:
 		Surface(const std::string& name = "DefaultName"); //!< Default constructor with optional surface name.
 		Surface(std::vector<Vector3>, std::vector<Triangle>, const std::string& name = "DefaultName"); //!< Constructor that initializes the surface with points, triangles, and an optional name.
-		int get_nb_trgls(); //!< Returns the number of triangles in the surface.
-		int get_nb_pts(); //!< Returns the number of points in the surface.
+		int get_nb_trgls() const; //!< Returns the number of triangles in the surface.
+		int get_nb_pts() const; //!< Returns the number of points in the surface.
 		bool is_empty() const; //!< Checks if the surface is empty (no points or triangles).
-		const Triangle& get_triangle(const int& i); //!< Returns the triangle at index i.
-		const Triangle& get_triangle(const int& i) const; //!< Returns the triangle at index i (const version).
+		const Triangle& get_triangle(const int& i) const; //!< Returns the triangle at index i.
 		const Vector3& get_node(const int& i) const; //!< Returns the point (node) at index i.
 		Vector3 nearest(Vector3 p1, Vector3 p2, Vector3 ptest); //!< Finds the nearest point between two points p1 and p2 to the test point ptest.
 		Vector3 nearest(Vector3 p1, Vector3 p2, Vector3 p3, Vector3 ptest); //!< Finds the nearest point among three points p1, p2, and p3 to the test point ptest.
@@ -499,7 +498,7 @@ namespace KarstNSim {
 	\brief Returns the number of triangles in the surface.
 	\return The number of triangles.
 	*/
-	inline int Surface::get_nb_trgls() {
+	inline int Surface::get_nb_trgls() const {
 		return int(trgls_.size());
 	}
 
@@ -507,7 +506,7 @@ namespace KarstNSim {
 	\brief Returns the number of points in the surface.
 	\return The number of points.
 	*/
-	inline int Surface::get_nb_pts() {
+	inline int Surface::get_nb_pts() const {
 		return int(pts_.size());
 	}
 
@@ -521,15 +520,6 @@ namespace KarstNSim {
 
 	/*!
 	\brief Returns the triangle at index i.
-	\param i The index of the triangle.
-	\return A reference to the triangle at index i.
-	*/
-	inline const Triangle& Surface::get_triangle(const int& i) {
-		return trgls_[i];
-	}
-
-	/*!
-	\brief Returns the triangle at index i (const version).
 	\param i The index of the triangle.
 	\return A constant reference to the triangle at index i.
 	*/

--- a/KarstNSim/include/KarstNSim/graph.h
+++ b/KarstNSim/include/KarstNSim/graph.h
@@ -41,6 +41,7 @@ If you use this code, pleace cite : Paris et al., 2021, Computer Graphic Forum.
 #include "KarstNSim/write_files.h"
 #include "KarstNSim/randomgenerator.h"
 #include "KarstNSim/simplex_noise.h"
+#include "KarstNSim/models/results.h"
 #include <iomanip>
 
 namespace KarstNSim {
@@ -695,7 +696,7 @@ namespace KarstNSim {
 		\param geologicalparams The geological parameters of the simulation.
 		\param network_name The name of the generated network.
 		*/
-		void create_line(const GeologicalParameters& geologicalparams, std::string network_name) const;
+		KarstNetworkResult get_result(const GeologicalParameters& geologicalparams, std::string network_name) const;
 
 		/*!
 		\brief Generates a set of deadend points in the karstic skeleton bounding box. Used in amplify_deadend.

--- a/KarstNSim/include/KarstNSim/graph.h
+++ b/KarstNSim/include/KarstNSim/graph.h
@@ -437,9 +437,10 @@ namespace KarstNSim {
 		\param costsFinal The costs associated with the final paths.
 		\param vadoseFinal Vadose zone flags for the final paths (true if in the vadose zone, false in the phreatic zone).
 		\param springidxFinal The index of the spring associated with each generated path of the skeleton.
+		\param save_new_matrix A flag indicating whether to save the new connectivity matrix (with resolved "uncertain" connections).
 		*/
 		void ComputeKarsticSkeleton(const std::vector<KeyPoint>& pts, const float fraction_karst_perm, std::vector<std::vector<int>>& pathsFinal, std::vector<std::vector<float>>& costsFinal, std::vector<std::vector<char>>& vadoseFinal,
-			std::vector<int>& springidxFinal);
+			std::vector<int>& springidxFinal, bool save_new_matrix);
 
 		/*!
 		\brief Finds the shortest path between two nodes in the graph.

--- a/KarstNSim/include/KarstNSim/graph.h
+++ b/KarstNSim/include/KarstNSim/graph.h
@@ -359,7 +359,7 @@ namespace KarstNSim {
 		\param centers2D The 2D coordinates of the centers of each triangle of the inception surface, stored in a PointCloud.
 		\return True if the point is below the surface, otherwise false.
 		*/
-		static bool CheckBelowSurf(const Vector3&, const Surface*, const PointCloud& centers2D);
+		static bool CheckBelowSurf(const Vector3&, const Surface&, const PointCloud& centers2D);
 
 
 		/*!
@@ -370,21 +370,21 @@ namespace KarstNSim {
 		\param centers2D The 2D coordinates of the centers of each triangle of the inception surface, stored in a PointCloud.
 		\return The computed distance to the surface.
 		*/
-		float distsurf(const Vector3& pt, Surface* surface, const float& max_inception_surface_distance, const PointCloud& centers2D);
+		float distsurf(const Vector3& pt, const Surface& surface, const float& max_inception_surface_distance, const PointCloud& centers2D) const;
 
 		/*!
 		\brief Computes the Euclidean distance of each sample to its closest inception surface (fills samples_surf_dist)
 		\param surfaces A vector of all the inception surfaces to compute the distance to.
 		\param max_inception_surface_distance Dmax, the maximum inception surface distance of influence.
 		*/
-		void compute_euclidian_distance_from_surfaces(std::vector<Surface> *surfaces, const float max_inception_surface_distance);
+		void compute_euclidian_distance_from_surfaces(const std::vector<Surface>& surfaces, const float max_inception_surface_distance);
 
 		/*!
 		\brief Computes the Euclidean distance of each sample to each water table (fills samples_wt_dist)
 		\param surfaces A vector of all the water table surfaces to compute the distance to.
 		\param distance Dmax, the maximum inception surface distance of influence.
 		*/
-		void compute_euclidian_distance_from_wt(std::vector<Surface> *surfaces, const float max_inception_surface_distance);
+		void compute_euclidian_distance_from_wt(const std::vector<Surface>& surfaces, const float max_inception_surface_distance);
 
 		/*!
 		\brief Saves the nearest neighbor graph (Warning: HEAVY).
@@ -424,10 +424,10 @@ namespace KarstNSim {
 		*/
 		void InitializeCostGraph(const bool create_nghb_graph, const bool create_nghb_graph_property, const std::vector<KeyPoint>& keypts,
 			const GeologicalParameters& geologicalparams, std::vector<Vector3>& nodes_on_inception_surfaces, std::vector<std::vector<Vector3>>& nodes_on_wt_surfaces,
-			std::vector<Surface>* inception_horizons,
-			std::vector<Surface>* water_tables, const bool use_sampling_points, Box* Box, const float max_inception_surface_distance, std::vector<Vector3>* sampling_points,
-			const bool create_surf_sampling, const bool use_density_property, int k_pts, const float fraction_karst_perm, std::vector<float> propdensity,
-			std::vector<float> propikp, Surface* topo_surface);
+			const std::vector<Surface>& inception_horizons,
+			const std::vector<Surface>& water_tables, const bool use_sampling_points, const Box& Box, const float max_inception_surface_distance, const std::vector<Vector3>& sampling_points,
+			const bool create_surf_sampling, const bool use_density_property, int k_pts, const float fraction_karst_perm, const std::vector<float>& propdensity,
+			const std::vector<float>& propikp, const Surface& topo_surface);
 
 
 		/*!
@@ -514,13 +514,13 @@ namespace KarstNSim {
 		\param propdensity Property density, which is used if use_density_property is True.
 		\param topo_surface The topographic surface.
 		*/
-		void SampleSpaceDwork(Box* Box, const bool use_density_property, const int k, std::vector<float> propdensity, Surface* topo_surface);
+		void SampleSpaceDwork(const Box& box, const bool use_density_property, const int k, const std::vector<float>& propdensity, const Surface& topo_surface);
 
 		/*!
 		\brief Defines flags for the water table surfaces.
 		\param water_tables A vector of all the water table surfaces.
 		*/
-		void DefineWSurfaceFlags(std::vector<Surface>* water_tables);
+		void DefineWSurfaceFlags(const std::vector<Surface>& water_tables);
 
 		/*!
 		\brief Builds the nearest neighbor direct cost graph based on the provided parameters.
@@ -529,7 +529,7 @@ namespace KarstNSim {
 		\param max_dist_surf Dmax, the maximum distance of influence of inception surfaces.
 		\param keypts A vector of all KeyPoint objects (inlets, outlets, waypoints).
 		*/
-		void BuildNearestNeighbourGraph(Box*, const float fraction_old_karst_perm, float max_dist_surf, const std::vector<KeyPoint>& keypts);
+		void BuildNearestNeighbourGraph(const Box& box, const float fraction_old_karst_perm, float max_dist_surf, const std::vector<KeyPoint>& keypts);
 
 		/*!
 		\brief Saves the noise vector for the given set of points as a new box property.
@@ -613,7 +613,7 @@ namespace KarstNSim {
 		* @param water_tables the selected water tables
 		* @return a ratio between 0 and 1
 		*/
-		float compute_wt_ratio(GraphOperations* graph, std::vector<Surface>* water_tables);
+		float compute_wt_ratio(const GraphOperations& graph, const std::vector<Surface>& water_tables);
 
 		/*!
 		\brief Counts the number of vadose zone nodes for a specific spring water table.

--- a/KarstNSim/include/KarstNSim/karstic_network.h
+++ b/KarstNSim/include/KarstNSim/karstic_network.h
@@ -35,6 +35,7 @@ If you use this code, please cite : Gouy et al., 2024, Journal of Hydrology.
 #include <cstring>
 #include <iomanip>
 #include <stdexcept>
+#include <optional>
 
 namespace KarstNSim {
 
@@ -261,7 +262,7 @@ namespace KarstNSim {
 		\param propikp Vector of IKP property of the box
 		\return Simulation time
 		*/
-		float run_simulation(const bool &sections_simulation_only, const bool &create_nghb_graph, const bool &create_nghb_graph_property,
+		std::optional<KarstNetworkResult> run_simulation(const bool &sections_simulation_only, const bool &create_nghb_graph, const bool &create_nghb_graph_property,
 							 const bool &create_solved_connectivity_matrix, const bool &use_amplification, const bool &use_sampling_points,
 							 const float &fraction_karst_perm, const float &fraction_old_karst_perm, const float &max_inception_surface_distance,
 							 std::vector<Vector3> *sampling_points, const bool &create_vset_sampling, const bool &use_density_property,

--- a/KarstNSim/include/KarstNSim/karstic_network.h
+++ b/KarstNSim/include/KarstNSim/karstic_network.h
@@ -247,6 +247,7 @@ namespace KarstNSim {
 		\param sections_simulation_only Boolean indicating whether to simulate sections only (and skip everything else)
 		\param create_nghb_graph Boolean to create nearest neighbor graph
 		\param create_nghb_graph_property Boolean to create nearest neighbor graph property
+		\param create_solved_connectivity_matrix Boolean to create the "solved" connectivity matrix (with resolved "uncertain" connections)
 		\param use_amplification Boolean to use amplification phase
 		\param use_sampling_points_ Boolean to use sampling points
 		\param fraction_karst_perm Cohesion factor Pred
@@ -260,9 +261,11 @@ namespace KarstNSim {
 		\param propikp Vector of IKP property of the box
 		\return Simulation time
 		*/
-		float run_simulation(const bool& sections_simulation_only, const bool& create_nghb_graph, const bool& create_nghb_graph_property, const bool& use_amplification, const bool& use_sampling_points_,
-			const float& fraction_karst_perm, const float& fraction_old_karst_perm, const float& max_inception_surface_distance, std::vector<Vector3>* sampling_points_, const bool& create_vset_sampling_,
-			const bool& use_density_property_, const int& k_pts, const std::vector<float>& propdensity, const std::vector<float>& propikp);
+		float run_simulation(const bool &sections_simulation_only, const bool &create_nghb_graph, const bool &create_nghb_graph_property,
+							 const bool &create_solved_connectivity_matrix, const bool &use_amplification, const bool &use_sampling_points,
+							 const float &fraction_karst_perm, const float &fraction_old_karst_perm, const float &max_inception_surface_distance,
+							 std::vector<Vector3> *sampling_points, const bool &create_vset_sampling, const bool &use_density_property,
+							 const int &k_pts, const std::vector<float> &propdensity, const std::vector<float> &propikp);
 
 		/*!
 		\brief Sets the save repertory if we want to create link and node files

--- a/KarstNSim/include/KarstNSim/karstic_network.h
+++ b/KarstNSim/include/KarstNSim/karstic_network.h
@@ -66,8 +66,8 @@ namespace KarstNSim {
 		\param water_tables water tables associated to each spring
 		*/
 
-		KarsticNetwork(const std::string& karstic_network_name, Box* Box, GeologicalParameters& params,
-			const std::vector<KeyPoint>& keypts, std::vector<Surface>* water_tables);
+		KarsticNetwork(const std::string& karstic_network_name, const Box& box, GeologicalParameters& params,
+			const std::vector<KeyPoint>& keypts, const std::vector<Surface>& water_tables);
 
 		/*!
 		\brief Set sink points into the key points vector
@@ -77,7 +77,7 @@ namespace KarstNSim {
 		\param use_sinks_radius Flag to indicate whether to use sink radii
 		\param propsinksradius Radii of sinks
 		*/
-		void set_sinks(const std::vector<Vector3>* sinks, const std::vector<int>& propsinksindex, const std::vector<int>& propsinksorder, bool use_sinks_radius, const std::vector<float>& propsinksradius);
+		void set_sinks(const std::vector<Vector3>& sinks, const std::vector<int>& propsinksindex, const std::vector<int>& propsinksorder, bool use_sinks_radius, const std::vector<float>& propsinksradius);
 
 		/*!
 		\brief Puts all spring points in the keypoint vector
@@ -88,7 +88,7 @@ namespace KarstNSim {
 		\param propsinksradius Radii of sinks
 		\param propspringswtsurf Associated water table surfaces for springs
 		*/
-		void set_springs(const std::vector<Vector3>* springs, const std::vector<int>& propspringsindex, const bool& allow_single_outlet_connection, bool use_sinks_radius, const std::vector<float>& propsinksradius, const std::vector<int>& propspringswtsurf);
+		void set_springs(const std::vector<Vector3>& springs, const std::vector<int>& propspringsindex, const bool& allow_single_outlet_connection, bool use_sinks_radius, const std::vector<float>& propsinksradius, const std::vector<int>& propspringswtsurf);
 
 		/*!
 		\brief Set way points into the key points vector
@@ -98,7 +98,7 @@ namespace KarstNSim {
 		\param propwaypointsimpactradius Impact radii for way points
 		\param waypoints_weight Weight for way points in simulation
 		*/
-		void set_waypoints(const std::vector<Vector3>* waypoints, bool use_waypoints_radius, const std::vector<float>& propwaypointsradius, const std::vector<float>& propwaypointsimpactradius, float waypoints_weight);
+		void set_waypoints(const std::vector<Vector3>& waypoints, bool use_waypoints_radius, const std::vector<float>& propwaypointsradius, const std::vector<float>& propwaypointsimpactradius, float waypoints_weight);
 
 		/*!
 		\brief Set the number and maximum distance of dead-end points
@@ -111,7 +111,7 @@ namespace KarstNSim {
 		\brief Adds previous networks to the generated graph
 		\param previous_networks Pointer to the list of lines representing the previous networks incorporated to the graph
 		*/
-		void set_previous_networks(const std::vector<Line>* previous_networks);
+		void set_previous_networks(const std::vector<Line>& previous_networks);
 
 		/*!
 		\brief Add nodes from surfaces for densified sampling
@@ -120,7 +120,7 @@ namespace KarstNSim {
 		\param refine_surface_sampling Level of surface sampling refinement
 		\param create_vset_sampling Flag to create a vertex set sampling
 		*/
-		void set_inception_surfaces_sampling(const std::string& network_name, std::vector<Surface>* surfaces_used_to_densify,
+		void set_inception_surfaces_sampling(const std::string& network_name, const std::vector<Surface>& surfaces_used_to_densify,
 			const int& refine_surface_sampling, const bool& create_vset_sampling);
 
 		/*!
@@ -128,14 +128,14 @@ namespace KarstNSim {
 		\param inception_horizons List of inception horizon surfaces
 		\param inception_horizon_constraint_weight Weight of the inception horizon constraint
 		*/
-		void set_wt_surfaces_sampling(const std::string& network_name, std::vector<Surface>* surfaces_used_to_densify,
+		void set_wt_surfaces_sampling(const std::string& network_name, const std::vector<Surface>& surfaces_used_to_densify,
 			const int& refine_surface_sampling);
 
 		/*!
 		\brief Set the topographic surface
 		\param topo_surface Pointer to the topographic surface
 		*/
-		void set_topo_surface(Surface* topo_surface);
+		void set_topo_surface(const Surface& topo_surface);
 
 		/*! \brief Configures ghost rocks for the simulation
 		\param grid Grid box representing the domain
@@ -148,14 +148,14 @@ namespace KarstNSim {
 		\param max_depth_horizon Pointer to maximum depth horizon surface
 		\param ghostrock_width Max width of ghost rock corridors
 		*/
-		void set_ghost_rocks(const Box& grid, std::vector<float>& ikp, Line* alteration_lines, const bool& interpolate_lines, const float& ghostrock_max_vertical_size, const bool& use_max_depth_constraint, const float& ghost_rock_weight, Surface* max_depth_horizon, const float& ghostrock_width);
+		void set_ghost_rocks(const Box& grid, std::vector<float>& ikp, const Line& alteration_lines, const bool& interpolate_lines, const float& ghostrock_max_vertical_size, const bool& use_max_depth_constraint, const float& ghost_rock_weight, Surface* max_depth_horizon, const float& ghostrock_width);
 
 		/*!
 		\brief Sets the simulation with the inception hoizon parameters if we want to use this constraint
 		\param inception_horizons Pointer list to surfaces representing the inception horizons
 		\param inception_horizon_constraint_weight Weight of the inception horizon constraint
 		*/
-		void set_inception_horizons_parameters(std::vector<Surface>* inception_horizons, const float& inception_horizon_constraint_weight);
+		void set_inception_horizons_parameters(const std::vector<Surface>& inception_horizons, const float& inception_horizon_constraint_weight);
 
 		/*!
 		\brief Sets the simulation so that it will not consider inception horizon constraint
@@ -175,7 +175,7 @@ namespace KarstNSim {
 		\param fracture_intensity intensity/norm of the fracture orienation vector
 		\param fracture_constraint_weight Weight of the fracture constraint
 		*/
-		void set_fracture_constraint_parameters(const std::vector<float>* fracture_families_orientations, const std::vector<float>* fracture_families_tolerance, const float& fracture_constraint_weight);
+		void set_fracture_constraint_parameters(const std::vector<float>& fracture_families_orientations, const std::vector<float>& fracture_families_tolerance, const float& fracture_constraint_weight);
 
 		/*!
 		\brief Sets the simulation so that it will not consider fracture constraint
@@ -187,7 +187,7 @@ namespace KarstNSim {
 		\param sphere_centers centers of the spheres
 		\param sphere_radius radius pf the spheres
 		*/
-		void set_no_karst_spheres_parameters(const std::vector<Vector3>* sphere_centers, const std::vector<float>& sphere_radius);
+		void set_no_karst_spheres_parameters(const std::vector<Vector3>& sphere_centers, const std::vector<float>& sphere_radius);
 
 		/*!
 		\brief Sets the simulation parameters for the sampling, neireast neighbor and gamma skeleton computation phases
@@ -216,7 +216,7 @@ namespace KarstNSim {
 		\param sinks Pointer to the list of sinks
 		\param springs Pointer to the list of springs
 		*/
-		void read_connectivity_matrix(const std::string& simulation_input_dir, const std::vector<Vector3>* sinks, const std::vector<Vector3>* springs);
+		void read_connectivity_matrix(const std::string& simulation_input_dir, const std::vector<Vector3>& sinks, const std::vector<Vector3>& springs);
 
 		/*! \brief Sets noise parameters for the simulation
 		\param use_noise Boolean indicating whether to use noise for the cycle amplification step only
@@ -242,7 +242,7 @@ namespace KarstNSim {
 		\param max_depth_horizon Pointer to maximum depth horizon surface
 		\param ghostrock_width Width of ghost rocks
 		*/
-		void run_simulation_properties(KarsticSkeleton& skel, Line* alteration_lines, const bool& use_ghost_rocks, const float& ghostrock_max_vertical_size, const bool& use_max_depth_constraint, Surface* max_depth_horizon, const float& ghostrock_width);
+		void run_simulation_properties(KarsticSkeleton& skel, const Line& alteration_lines, const bool& use_ghost_rocks, const float& ghostrock_max_vertical_size, const bool& use_max_depth_constraint, const Surface& max_depth_horizon, const float& ghostrock_width);
 
 		/*! \brief Runs the simulation and returns the time required for the simulation
 		\param sections_simulation_only Boolean indicating whether to simulate sections only (and skip everything else)
@@ -265,7 +265,7 @@ namespace KarstNSim {
 		std::optional<KarstNetworkResult> run_simulation(const bool &sections_simulation_only, const bool &create_nghb_graph, const bool &create_nghb_graph_property,
 							 const bool &create_solved_connectivity_matrix, const bool &use_amplification, const bool &use_sampling_points,
 							 const float &fraction_karst_perm, const float &fraction_old_karst_perm, const float &max_inception_surface_distance,
-							 std::vector<Vector3> *sampling_points, const bool &create_vset_sampling, const bool &use_density_property,
+							 const std::vector<Vector3>& sampling_points, const bool &create_vset_sampling, const bool &use_density_property,
 							 const int &k_pts, const std::vector<float> &propdensity, const std::vector<float> &propikp);
 
 		/*!
@@ -328,14 +328,14 @@ namespace KarstNSim {
 		std::vector<std::vector<Vector3>> nodes_on_wt_surfaces; /*!< List of nodes on water table surfaces */
 		std::vector<Vector3> pt_sink; /*!< Sinks */
 		std::vector<Vector3> pt_spring; /*!< Springs */
-		std::vector<Surface>* inception_horizons = nullptr; /*!< Inception horizon surfaces */
-		std::vector<Surface>* water_tables = nullptr; /*!< Water table surfaces */
-		Surface* topo_surface_ = nullptr; /*!< Topographic surface */
+		std::vector<Surface> inception_horizons; /*!< Inception horizon surfaces */
+		std::vector<Surface> water_tables; /*!< Water table surfaces */
+		Surface topo_surface_; /*!< Topographic surface */
 		bool is_simulation_parametrized = false; /*!< Flag indicating whether the simulation is parametrized or not*/
 		bool use_deadend_pts_ = false; /*!< Flag indicating whether deadend amplification should be applied */
 		int nb_deadend_points_; /*!< Number of dead-end points */
 		float max_distance_of_deadend_pts_; /*!< Maximum distance for dead-end points */
-		Box* box; /*!< Bounding box of the simulation */
+		Box box; /*!< Bounding box of the simulation */
 		GeologicalParameters params; /*!< Geological parameters */
 		GeostatParams geostatparams; /*!< Geostatistical parameters */
 		std::vector<KeyPoint> keypts; /*!< Keypoints for simulation */

--- a/KarstNSim/include/KarstNSim/models/results.h
+++ b/KarstNSim/include/KarstNSim/models/results.h
@@ -1,0 +1,50 @@
+#pragma once
+#include <KarstNSim/basics.h>
+
+namespace KarstNSim {
+
+    struct ResultPoint {
+        Vector3 p; //!< The 3D coordinates of the point.
+        float cost; //!< The cost associated with the point.
+        float equivalent_radius; //!< The equivalent radius at the point.
+        int branch_id; //!< The branch ID associated with the point.
+        bool vadose_flag; //!< A flag indicating if the point is in the vadose zone.
+    };
+
+    struct ResultSegment {
+        ResultPoint start; //!< The starting point of the segment.
+        ResultPoint end; //!< The ending point of the segment.
+    };
+
+    class KarstNetworkResult {
+    public:
+        //!< Convert the result to a string representation, for easy saving to a file
+        std::string to_string() const {
+            auto header_line = "Index\tX\tY\tZ\tcost\tequivalent_radius\tbranch_id\tvadose_flag";
+            std::string result = header_line;
+            int index = 0;
+            for (const auto& segment : _segments) {
+                // index is duped for both start and end points of the segment
+                for (const auto& point : { segment.start, segment.end }) {
+                    result += "\n" + std::to_string(index) + "\t" +
+                        std::to_string(point.p.x) + "\t" +
+                        std::to_string(point.p.y) + "\t" +
+                        std::to_string(point.p.z) + "\t" +
+                        std::to_string(point.cost) + "\t" +
+                        std::to_string(point.equivalent_radius) + "\t" +
+                        std::to_string(point.branch_id) + "\t" +
+                        std::to_string(point.vadose_flag ? 1 : 0);
+                }
+                index++;
+            }
+            return result;
+        }
+
+        //!< Add a segment to the karst network result.
+        void add_segment(const ResultPoint& start, const ResultPoint& end) {
+            _segments.push_back({ start, end });
+        }
+    protected:
+        std::vector<ResultSegment> _segments; //!< List of segments in the karst network.
+    };
+}

--- a/KarstNSim/include/KarstNSim/models/results.h
+++ b/KarstNSim/include/KarstNSim/models/results.h
@@ -16,14 +16,15 @@ namespace KarstNSim {
         ResultPoint end; //!< The ending point of the segment.
     };
 
-    class KarstNetworkResult {
-    public:
+    struct KarstNetworkResult {
+        std::vector<ResultSegment> segments; //!< List of segments in the karst network.
+
         //!< Convert the result to a string representation, for easy saving to a file
         std::string to_string() const {
             auto header_line = "Index\tX\tY\tZ\tcost\tequivalent_radius\tbranch_id\tvadose_flag";
             std::string result = header_line;
             int index = 0;
-            for (const auto& segment : _segments) {
+            for (const auto& segment : segments) {
                 // index is duped for both start and end points of the segment
                 for (const auto& point : { segment.start, segment.end }) {
                     result += "\n" + std::to_string(index) + "\t" +
@@ -42,9 +43,7 @@ namespace KarstNSim {
 
         //!< Add a segment to the karst network result.
         void add_segment(const ResultPoint& start, const ResultPoint& end) {
-            _segments.push_back({ start, end });
+            segments.push_back({ start, end });
         }
-    protected:
-        std::vector<ResultSegment> _segments; //!< List of segments in the karst network.
     };
 }

--- a/KarstNSim/include/KarstNSim/run_code.h
+++ b/KarstNSim/include/KarstNSim/run_code.h
@@ -230,6 +230,7 @@ namespace KarstNSim {
 		bool create_vset_sampling = true; //!< Flag to save sampling points.
 		bool create_nghb_graph = false; //!< Flag to save nearest neighbor graph (quite heavy object!)
 		bool create_nghb_graph_property = false; //!< Flag to save nearest neighbor graph property (very heavy object!!)
+		bool create_solved_connectivity_matrix = false; //!< Flag to save "solved" connectivity matrix (with resolved "uncertain" connections)
 		bool create_grid = false; //!< Flag to save grid data.
 
 		// parameters not included formally with a tag in the prompt file, but defined in another file (properties) :

--- a/KarstNSim/include/KarstNSim/surface_sampling.h
+++ b/KarstNSim/include/KarstNSim/surface_sampling.h
@@ -49,7 +49,7 @@ namespace KarstNSim {
 		A value of n means that this fractal pattern operation is operated n times.
 		\param create_surface_sampling option which will create an ASCII file with only the points sampled on the surfaces if set to true.
 		*/
-		static void multiple_surface_sampling(std::string directoryname, std::string network_name, KarstNSim::Box* Box, std::vector<Surface>* Surface, std::vector<Vector3>& Points, const int refine_surface_sampling, const bool create_surface_sampling);
+		static void multiple_surface_sampling(std::string directoryname, std::string network_name, const KarstNSim::Box& Box, const std::vector<Surface>& Surface, std::vector<Vector3>& Points, const int refine_surface_sampling, const bool create_surface_sampling);
 
 	};
 }

--- a/KarstNSim/include/KarstNSim/write_files.h
+++ b/KarstNSim/include/KarstNSim/write_files.h
@@ -30,24 +30,21 @@ If you use this code, please cite : Gouy et al., 2024, Journal of Hydrology.
 #include <iomanip>
 #include <filesystem>
 #include <sstream>
-#ifdef _WIN32
-#include <direct.h> // for mkdir on Windows
-#else
-#include <sys/stat.h> // for mkdir on Unix-like systems
-#endif
 
 namespace KarstNSim {
 	/**
-	 * @brief Adjusts a file name to reflect the last existing version in the save directory.
+	 * @brief Generate a unique filename by appending (0), (1), etc. if needed
 	 *
-	 * This function modifies the given file name to the "last existing" version in the sequence.
-	 * If no files with the same name exist, the file name remains unchanged. If files with the same
-	 * name (or numbered versions) already exist, the file name is updated to match the highest numbered version.
+	 * This function takes a base filename and directory and returns a unique filesystem path.
+	 * If the original filename doesn't exist, it returns it as-is. If it does exist,
+	 * it appends (0), (1), (2), etc. until a unique filename is found.
 	 *
-	 * @param file_name [in,out] The name of the file to be adjusted. It will be updated to the last existing version.
-	 * @param save_directory The directory where the file is being saved.
+	 * @param base_filename The desired filename (without directory path)
+	 * @param save_directory The directory where the file will be saved
+	 * @return std::filesystem::path A unique file path in the specified directory
 	 */
-	void adjust_file_name_to_last(std::string& file_name, const std::string& save_directory);
+	std::filesystem::path make_unique_filename(const std::string& base_filename, const std::string& save_directory);
+	
 	/*!
 	 \brief Saves point in ASCII file
 
@@ -60,7 +57,7 @@ namespace KarstNSim {
 	 \param property_names Vector of string with names of the properties of points.
 	 \param properties Vector of float with values of the point for each property.
 	!*/
-	void save_point(std::string& file_name, const std::string& save_directory, Vector3 u, std::vector<std::string> property_names = {}, std::vector<float> properties = {});
+	void save_point(const std::string& file_name, const std::string& save_directory, Vector3 u, std::vector<std::string> property_names = {}, std::vector<float> properties = {});
 	/**
 	* @brief Saves triangulated surface in ASCII file
 	*
@@ -75,7 +72,7 @@ namespace KarstNSim {
 	* @param property_names Vector of string with names of the properties of the surface.
 	* @param properties Vector of vector of float with values of the nodes of the surface for each property. Format : properties[i][j] is the property j of node i.
 	**/
-	void save_surface(std::string& file_name, const std::string& save_directory, Surface s, std::vector<std::string> property_names = {}, std::vector<std::vector<float>> properties = {});
+	void save_surface(const std::string& file_name, const std::string& save_directory, Surface s, std::vector<std::string> property_names = {}, std::vector<std::vector<float>> properties = {});
 	/**
 	* @brief Saves pointset in ASCII file
 	*
@@ -88,7 +85,7 @@ namespace KarstNSim {
 	* @param property_names Vector of string with names of the properties of the pointset.
 	* @param properties Vector of vector of float with values of the nodes of the pointset for each property. Format : properties[i][j] is the property j of node i.
 	*/
-	void save_pointset(std::string& file_name, const std::string& save_directory, std::vector<Vector3> pset, std::vector<std::string> property_names = {}, std::vector<std::vector<float>> properties = {});
+	void save_pointset(const std::string& file_name, const std::string& save_directory, std::vector<Vector3> pset, std::vector<std::string> property_names = {}, std::vector<std::vector<float>> properties = {});
 	/**
 	* @brief Saves line in ASCII file
 	*
@@ -101,23 +98,20 @@ namespace KarstNSim {
 	* @param property_names Vector of string with names of the properties of the line.
 	* @param properties Vector of vector of float with values of the nodes of the surface for each property. Format : properties[i][j] is the property j of node i.
 	*/
-	void save_line(std::string& file_name, const std::string& save_directory, Line pline, std::vector<std::string> property_names = {}, std::vector<std::vector<std::vector<float>>> properties = {});
+	void save_line(const std::string& file_name, const std::string& save_directory, Line pline, std::vector<std::string> property_names = {}, std::vector<std::vector<std::vector<float>>> properties = {});
 
-	void save_connectivity_matrix(std::string& file_name, const std::string& save_directory, Array2D<int> matrix);
+	void save_connectivity_matrix(const std::string& file_name, const std::string& save_directory, Array2D<int> matrix);
 
 	/**
-	* @brief Saves triangulated surface in ASCII file
+	* @brief Saves box in ASCII file
 	*
-	* This function saves a given surface, represented by its individual vertices and
-	* its triangles. The output file will first display the vertices coordinates and property values,
-	* under the prefix 'VRTX', and then display the indices of the vertices of each triangle, under
-	* the prefix 'TRGL'.
+	* This function saves a given box with its parameters and properties.
 	*
 	* @param file_name Name of the created file.
 	* @param save_directory Location of the created file.
-	* @param s Surface to be saved
-	* @param property_names Vector of string with names of the properties of the surface
-	* @param properties Vector of vector of float with values of the nodes of the surface for each property. Format : properties[i][j] is the property j of node i.
+	* @param box Box to be saved
+	* @param property_names Vector of string with names of the properties of the box
+	* @param properties Vector of vector of float with values of the nodes of the box for each property. Format : properties[i][j] is the property j of node i.
 	*/
-	void save_box(std::string& file_name, const std::string& save_directory, Box box, std::vector<std::string> property_names = {}, std::vector<std::vector<float>> properties = {});
+	void save_box(const std::string& file_name, const std::string& save_directory, Box box, std::vector<std::string> property_names = {}, std::vector<std::vector<float>> properties = {});
 }

--- a/KarstNSim/src/cost_graph.cpp
+++ b/KarstNSim/src/cost_graph.cpp
@@ -197,6 +197,12 @@ namespace KarstNSim {
 				}
 			}
 		}
+		if (!path.empty()) {
+			const std::size_t desired = path.size();
+			if (path_cost.size() < desired) {
+				path_cost.insert(path_cost.begin(), desired - path_cost.size(), 0.f);
+			}
+		}
 		return std::make_pair(path, path_cost);
 	}
 

--- a/KarstNSim/src/ghost_rocks.cpp
+++ b/KarstNSim/src/ghost_rocks.cpp
@@ -52,7 +52,7 @@ namespace KarstNSim {
 		closest_point_on_closest_segment_to_point_in_polyline(pt, polyline, closest_point, min_distance_sq);
 		// check that the z of the cell pt is within boundaries of the ghost-rock (and, if used, above the substratum horizon)
 		if (use_max_depth_constraint) {
-			if (pt.z < closest_point.z - length || pt.z > closest_point.z || GraphOperations::CheckBelowSurf(pt, &substratum_surf, centers2D)) {
+			if (pt.z < closest_point.z - length || pt.z > closest_point.z || GraphOperations::CheckBelowSurf(pt, substratum_surf, centers2D)) {
 				return false;
 			}
 		}

--- a/KarstNSim/src/graph_operations.cpp
+++ b/KarstNSim/src/graph_operations.cpp
@@ -21,25 +21,25 @@ namespace KarstNSim {
 	}
 
 	// Samples the domain with Dwork's algorithm adapted in 3D
-	void GraphOperations::SampleSpaceDwork(Box* box,
-		const bool use_density_property, const int k, std::vector<float> propdensity, Surface* topo_surface) {
+	void GraphOperations::SampleSpaceDwork(const Box& box,
+		const bool use_density_property, const int k, const std::vector<float>& propdensity, const Surface& topo_surface) {
 
 		//const clock_t time1 = clock();
-		PointCloud centers2D = topo_surface->get_centers_cloud(2);
+		PointCloud centers2D = topo_surface.get_centers_cloud(2);
 
-		float min_z_topo = topo_surface->get_boundbox_min().z;
+		float min_z_topo = topo_surface.get_boundbox_min().z;
 
 		// 1 //
 		//First, we get the Box characteristics (origin and dimensions in each direction as well as density property).
 		//The density property must be defined on a grid with int(sqrt(3) / r_min) cells in each direction, with r_min the
 		//minimum density defined in the whole grid (0<rmin<1, e.g., 0.01).
 
-		const Vector3& ptmin = box->get_basis();
-		const Vector3& ptmax = box->get_end();
+		const Vector3& ptmin = box.get_basis();
+		const Vector3& ptmax = box.get_end();
 
-		const Vector3 u = box->get_u();
-		const Vector3 v = box->get_v();
-		const Vector3 w = box->get_w();
+		const Vector3 u = box.get_u();
+		const Vector3 v = box.get_v();
+		const Vector3 w = box.get_w();
 
 		float delta_y = ptmax.y - ptmin.y;
 		float delta_x = ptmax.x - ptmin.x;
@@ -65,7 +65,7 @@ namespace KarstNSim {
 
 		Vector3 min(ptmin.x, ptmin.y, ptmin.z);
 		float r_min = 0;
-		int nu = box->get_nu(), nv = box->get_nv(), nw = box->get_nw(); //number of samples in u,v,w axis
+		int nu = box.get_nu(), nv = box.get_nv(), nw = box.get_nw(); //number of samples in u,v,w axis
 
 		float r_cst = 0;
 		// We open the property if that's what the user asked for
@@ -307,11 +307,10 @@ namespace KarstNSim {
 			}
 		}
 
-		propdensity.clear();
 		grid.clear(); 	// Get rid of the map memory
 	}
 
-	bool GraphOperations::CheckBelowSurf(const Vector3& pt, const Surface* surface, const PointCloud& centers2D)
+	bool GraphOperations::CheckBelowSurf(const Vector3& pt, const Surface& surface, const PointCloud& centers2D)
 	{
 		const int number_of_tries = 5;
 		bool found_triangle = false;
@@ -320,9 +319,9 @@ namespace KarstNSim {
 		std::vector<Neighbour> candidates;
 		centers2D.findNearestNeighbors(pt2D, -1, number_of_tries, 1e25f, candidates);
 		for (int test = 0; test < number_of_tries; test++) {
-			const Triangle& trgl_i = surface->get_triangle(candidates[test].i);
+			const Triangle& trgl_i = surface.get_triangle(candidates[test].i);
 			const int& pt1 = trgl_i.point(0), pt2 = trgl_i.point(1), pt3 = trgl_i.point(2);
-			const Vector3& p1 = surface->get_node(pt1), p2 = surface->get_node(pt2), p3 = surface->get_node(pt3);
+			const Vector3& p1 = surface.get_node(pt1), p2 = surface.get_node(pt2), p3 = surface.get_node(pt3);
 			if (isInsideTriangle(p1, p2, p3, pt)) {
 				found_triangle = true;
 				P1 = p1;
@@ -335,7 +334,7 @@ namespace KarstNSim {
 		return (is_point_under_triangle(pt, P1, P2, P3));
 	}
 
-	float GraphOperations::distsurf(const Vector3& pt, Surface* surface, const float& max_inception_surface_distance, const PointCloud& centers2D)
+	float GraphOperations::distsurf(const Vector3& pt, const Surface& surface, const float& max_inception_surface_distance, const PointCloud& centers2D) const
 	{
 		const int number_of_tries = 5;
 		bool found_triangle = false;
@@ -345,9 +344,9 @@ namespace KarstNSim {
 		centers2D.findNearestNeighbors(pt2D, -1, number_of_tries, 1e25f, candidates);
 
 		for (int test = 0; test < number_of_tries; test++) {
-			const Triangle& trgl_i = surface->get_triangle(candidates[test].i);
+			const Triangle& trgl_i = surface.get_triangle(candidates[test].i);
 			const int& pt1 = trgl_i.point(0), pt2 = trgl_i.point(1), pt3 = trgl_i.point(2);
-			const Vector3& p1 = surface->get_node(pt1), p2 = surface->get_node(pt2), p3 = surface->get_node(pt3);
+			const Vector3& p1 = surface.get_node(pt1), p2 = surface.get_node(pt2), p3 = surface.get_node(pt3);
 
 			if (isInsideTriangle(p1, p2, p3, pt)) {
 				found_triangle = true;
@@ -370,33 +369,33 @@ namespace KarstNSim {
 		return distance;
 	}
 
-	void GraphOperations::DefineWSurfaceFlags(std::vector<Surface>* water_tables) {
+	void GraphOperations::DefineWSurfaceFlags(const std::vector<Surface>& water_tables) {
 
 		// First and foremost, a water table doesn't project on the whole domain all the time.
 		// Therefore any point outside of the projected perimeter of the water table can be considered in the vadose zone.
 		std::vector<PointCloud> all_centers2D;
 
 		std::vector<std::vector<float>> coord_boundbox_wt(params.nb_wt, std::vector<float>(4)); // elements are sorted as followed : xmin,ymin,xmax,ymax
-		for (int i = 0; i < water_tables->size(); i++) {
-			Vector3 min_wt = water_tables->at(i).get_boundbox_min();
+		for (int i = 0; i < water_tables.size(); i++) {
+			Vector3 min_wt = water_tables[i].get_boundbox_min();
 			coord_boundbox_wt[i][0] = min_wt.x;
 			coord_boundbox_wt[i][1] = min_wt.y;
-			Vector3 max_wt = water_tables->at(i).get_boundbox_max();
+			Vector3 max_wt = water_tables[i].get_boundbox_max();
 			coord_boundbox_wt[i][2] = max_wt.x;
 			coord_boundbox_wt[i][3] = max_wt.y;
-			PointCloud centers2D = water_tables->at(i).get_centers_cloud(2);
+			PointCloud centers2D = water_tables[i].get_centers_cloud(2);
 			all_centers2D.push_back(centers2D);
 		}
 		samples_surf_flags.resize(int(samples.size()), params.nb_wt);
 		for (int i = 0; i<int(samples.size()); i++) {
 
-			for (int j = 0; j < water_tables->size(); j++) {
+			for (int j = 0; j < water_tables.size(); j++) {
 				bool check;
 				if ((samples[i].x < coord_boundbox_wt[j][0]) || (samples[i].x > coord_boundbox_wt[j][2]) || (samples[i].y < coord_boundbox_wt[j][1]) || (samples[i].y > coord_boundbox_wt[j][3])) { // out of wt bonds
 					check = false;
 				}
 				else {
-					Surface* surf_j = &water_tables->at(j);
+					const Surface& surf_j = water_tables[j];
 
 					check = CheckBelowSurf(samples[i], surf_j, all_centers2D[j]);
 				}
@@ -405,19 +404,19 @@ namespace KarstNSim {
 		}
 	}
 
-	void GraphOperations::compute_euclidian_distance_from_wt(std::vector<Surface> *surfaces, const float max_inception_surface_distance) {
+	void GraphOperations::compute_euclidian_distance_from_wt(const std::vector<Surface>& surfaces, const float max_inception_surface_distance) {
 
 		std::vector<PointCloud> all_centers2D;
-		for (int i = 0; i < surfaces->size(); i++) {
-			PointCloud centers2D = surfaces->at(i).get_centers_cloud(2);
+		for (int i = 0; i < surfaces.size(); i++) {
+			PointCloud centers2D = surfaces[i].get_centers_cloud(2);
 			all_centers2D.push_back(centers2D);
 		}
 
 		samples_wt_dist.resize(int(samples.size()), params.nb_wt);
 		std::vector<float> max_dist_wt(params.nb_wt, 0.);
 		std::vector<float> min_dist_wt(params.nb_wt, std::numeric_limits<float>::infinity());
-		for (int j = 0; j < surfaces->size(); j++) {
-			Surface* surf_j = &surfaces->at(j);
+		for (int j = 0; j < surfaces.size(); j++) {
+			const Surface& surf_j = surfaces[j];
 			for (int i = 0; i<int(samples.size()); i++) {
 				float distance = distsurf(samples[i], surf_j, max_inception_surface_distance, all_centers2D[j]);
 				samples_wt_dist[i][j] = distance;
@@ -425,19 +424,19 @@ namespace KarstNSim {
 		}
 	}
 
-	void GraphOperations::compute_euclidian_distance_from_surfaces(std::vector<Surface> *surfaces, const float max_inception_surface_distance) {
+	void GraphOperations::compute_euclidian_distance_from_surfaces(const std::vector<Surface>& surfaces, const float max_inception_surface_distance) {
 
 		std::vector<PointCloud> all_centers2D;
-		for (int i = 0; i < surfaces->size(); i++) {
-			PointCloud centers2D = surfaces->at(i).get_centers_cloud(2);
+		for (int i = 0; i < surfaces.size(); i++) {
+			PointCloud centers2D = surfaces[i].get_centers_cloud(2);
 			all_centers2D.push_back(centers2D);
 		}
 
 		samples_surf_dist.resize(int(samples.size()));
 		for (int i = 0; i<int(samples.size()); i++) {
 			float max_dist_surf_iter = std::numeric_limits<float>::infinity();
-			for (int j = 0; j < surfaces->size(); j++) {
-				Surface* surf_j = &surfaces->at(j);
+			for (int j = 0; j < surfaces.size(); j++) {
+				const Surface& surf_j = surfaces[j];
 				float distance = distsurf(samples[i], surf_j, max_inception_surface_distance, all_centers2D[j]);
 				max_dist_surf_iter = std::min(max_dist_surf_iter, distance);
 			}
@@ -566,15 +565,15 @@ namespace KarstNSim {
 
 	void GraphOperations::InitializeCostGraph(const bool create_nghb_graph, const bool create_nghb_graph_property, const std::vector<KeyPoint>& keypts,
 		const GeologicalParameters& geologicalparams, std::vector<Vector3>& nodes_on_inception_surfaces, std::vector<std::vector<Vector3>>& nodes_on_wt_surfaces,
-		std::vector<Surface>* inception_horizons, std::vector<Surface>* water_tables, const bool use_sampling_points,
-		Box* box, const float max_inception_surface_distance,
-		std::vector<Vector3>* sampling_points, const bool create_vset_sampling, const bool use_density_property, const int k_pts,
-		const float fraction_old_karst_perm, std::vector<float> propdensity, std::vector<float> propikp, Surface* topo_surface)
+		const std::vector<Surface>& inception_horizons, const std::vector<Surface>& water_tables, const bool use_sampling_points,
+		const Box& box, const float max_inception_surface_distance,
+		const std::vector<Vector3>& sampling_points, const bool create_vset_sampling, const bool use_density_property, const int k_pts,
+		const float fraction_old_karst_perm, const std::vector<float>& propdensity, const std::vector<float>& propikp, const Surface& topo_surface)
 	{
-		PointCloud centers2D = topo_surface->get_centers_cloud(2);
+		PointCloud centers2D = topo_surface.get_centers_cloud(2);
 		const clock_t time1 = clock();
 		params = geologicalparams;
-		int nu = box->get_nu(), nv = box->get_nv();
+		int nu = box.get_nu(), nv = box.get_nv();
 		std::vector<std::vector<int>> on_wt_flags_idx(params.nb_wt);
 		std::vector<std::vector<int>> on_surf_flags_idx(1);
 		Vector3 new_pt;
@@ -588,10 +587,10 @@ namespace KarstNSim {
 
 		// 1.2a we recover previously sampled points if any
 		if (use_sampling_points) {
-			for (int i = 0; i < sampling_points->size(); i++) {
-				new_pt.x = sampling_points->at(i).x;
-				new_pt.y = sampling_points->at(i).y;
-				new_pt.z = sampling_points->at(i).z;
+			for (int i = 0; i < sampling_points.size(); i++) {
+				new_pt.x = sampling_points[i].x;
+				new_pt.y = sampling_points[i].y;
+				new_pt.z = sampling_points[i].z;
 				samples.push_back(new_pt);
 			}
 		}
@@ -640,11 +639,11 @@ namespace KarstNSim {
 			float value_itr = 1.;
 			if (!use_sampling_points && use_density_property) {
 				int u1, v1, w1;
-				box->xyz2uvw_with_limits_conditions(nodes_on_inception_surfaces[i], u1, v1, w1);
+				box.xyz2uvw_with_limits_conditions(nodes_on_inception_surfaces[i], u1, v1, w1);
 				value_itr = propdensity[u1 + nu * v1 + nv * nu*w1];
 			}
 			bool below_top_test = true;
-			if (!topo_surface->is_empty()) {
+			if (!topo_surface.is_empty()) {
 				below_top_test = CheckBelowSurf(nodes_on_inception_surfaces[i], topo_surface, centers2D);
 			}
 			if (below_top_test && value_itr > 0) {  // Accept only nodes that are below topo surf AND are associated to a karstifiable zone (ie. propdensity >0)
@@ -666,11 +665,11 @@ namespace KarstNSim {
 				float value_itr = 1.;
 				if (!use_sampling_points && use_density_property) {
 					int u1, v1, w1;
-					box->xyz2uvw_with_limits_conditions(nodes_on_wt_surfaces[i][j], u1, v1, w1);
+					box.xyz2uvw_with_limits_conditions(nodes_on_wt_surfaces[i][j], u1, v1, w1);
 					value_itr = propdensity[u1 + nu * v1 + nv * nu*w1];
 				}
 				bool below_top_test = true;
-				if (!topo_surface->is_empty()) {
+				if (!topo_surface.is_empty()) {
 					below_top_test = CheckBelowSurf(nodes_on_wt_surfaces[i][j], topo_surface, centers2D);
 				}
 				if (below_top_test && value_itr > 0) {  // Accept only nodes that are below topo surf AND are associated to a karstifiable zone (ie. propdensity >0)
@@ -715,13 +714,13 @@ namespace KarstNSim {
 
 		// 2 Find the karstification potential for each point of the sampling cloud
 		if (params.karstificationCost.used) {
-			const Vector3 u = box->get_u();
-			const Vector3 v = box->get_v();
-			const Vector3 w = box->get_w();
-			int nu = box->get_nu(), nv = box->get_nv();
+			const Vector3 u = box.get_u();
+			const Vector3 v = box.get_v();
+			const Vector3 w = box.get_w();
+			int nu = box.get_nu(), nv = box.get_nv();
 			for (int i = 0; i < samples.size(); i++) {
 				int u1, v1, w1;
-				box->xyz2uvw_with_limits_conditions(samples[i], u1, v1, w1);
+				box.xyz2uvw_with_limits_conditions(samples[i], u1, v1, w1);
 				float value_itr = propikp[u1 + nu * v1 + nv * nu*w1];
 				if (value_itr < 0) { // a value smaller than  means a No data value, which means a cell above topography
 					samples_layer_kp.push_back(1); // maximal cost (this happens because of the discrepancy between the background grid's resolution and the points' position close to the topography)
@@ -729,7 +728,6 @@ namespace KarstNSim {
 				}
 				samples_layer_kp.push_back(1 - propikp[u1 + nu * v1 + nv * nu*w1]);
 			}
-			propikp.clear();
 		}
 
 		const clock_t time21 = clock();
@@ -750,7 +748,7 @@ namespace KarstNSim {
 
 		// 4 Compute the distance from each point to the inception surfaces and the water table surfaces
 		compute_euclidian_distance_from_wt(water_tables, max_inception_surface_distance);
-		if (inception_horizons != nullptr) {
+		if (!inception_horizons.empty()) {
 			compute_euclidian_distance_from_surfaces(inception_horizons, max_inception_surface_distance);
 		}
 		const clock_t time23 = clock();
@@ -818,17 +816,17 @@ namespace KarstNSim {
 		}
 	}
 
-	void GraphOperations::BuildNearestNeighbourGraph(Box* box, const float fraction_old_karst_perm, float max_dist_surf, const std::vector<KeyPoint>& keypts)
+	void GraphOperations::BuildNearestNeighbourGraph(const Box& box, const float fraction_old_karst_perm, float max_dist_surf, const std::vector<KeyPoint>& keypts)
 	{
 
 		float time_neigbhors = 0.;
 		float time_costs = 0.;
 
-		const Vector3& ptmin = box->get_basis();
-		const Vector3& ptmax = box->get_end();
-		const Vector3 u = box->get_u();
-		const Vector3 v = box->get_v();
-		const Vector3 w = box->get_w();
+		const Vector3& ptmin = box.get_basis();
+		const Vector3& ptmax = box.get_end();
+		const Vector3 u = box.get_u();
+		const Vector3 v = box.get_v();
+		const Vector3 w = box.get_w();
 		float delta_y_abs = std::abs(ptmax.y - ptmin.y);
 		float delta_x_abs = std::abs(ptmax.x - ptmin.x);
 		float delta_z_abs = std::abs(ptmax.z - ptmin.z);

--- a/KarstNSim/src/graph_operations.cpp
+++ b/KarstNSim/src/graph_operations.cpp
@@ -1059,7 +1059,7 @@ namespace KarstNSim {
 	}
 
 	void GraphOperations::ComputeKarsticSkeleton(const std::vector<KeyPoint>& pts, const float fraction_karst_perm, std::vector<std::vector<int>>& pathsFinal, std::vector<std::vector<float>>& costsFinal, std::vector<std::vector<char>>& vadoseFinal,
-		std::vector<int>& springidxFinal)
+		std::vector<int>& springidxFinal, bool save_new_connectivity_matrix)
 	{
 		float step1 = 0.0f, step2 = 0.0f, step3 = 0.0f, step4 = 0.0f, step5 = 0.0f, step6 = 0.0f, step7 = 0.0f, step8 = 0.0f, step_sink = 0.0f;
 		const clock_t time1 = clock();
@@ -1284,9 +1284,11 @@ namespace KarstNSim {
 			}
 		}
 
-		std::string full_dir_name = params.directoryname + "/outputs";
-		std::string full_name = params.scenename + "_connectivity_matrix.txt";
-		save_connectivity_matrix(full_name, full_dir_name, new_connectivity_matrix);
+		if (save_new_connectivity_matrix) {
+			std::string full_dir_name = params.directoryname + "/outputs";
+			std::string full_name = params.scenename + "_connectivity_matrix.txt";
+			save_connectivity_matrix(full_name, full_dir_name, new_connectivity_matrix);
+		}
 
 		clock_t time11 = clock();
 		step8 += float(time11 - time10) / CLOCKS_PER_SEC;

--- a/KarstNSim/src/graph_operations.cpp
+++ b/KarstNSim/src/graph_operations.cpp
@@ -1218,7 +1218,10 @@ namespace KarstNSim {
 				if (!already_reached && !path.empty()) {
 					vadose_full.insert(vadose_full.end(), path.size() - 1, false);
 					path_full.insert(path_full.end(), path.begin() + 1, path.end());
-					path_cost_full.insert(path_cost_full.end(), path_cost.begin() + 1, path_cost.end());
+					const std::size_t skip = path_cost.empty() ? 0u : 1u;
+					if (path_cost.size() > skip) {
+						path_cost_full.insert(path_cost_full.end(), path_cost.begin() + skip, path_cost.end());
+					}
 				}
 
 				all_paths[i][j] = path_full;

--- a/KarstNSim/src/graph_operations.cpp
+++ b/KarstNSim/src/graph_operations.cpp
@@ -95,11 +95,13 @@ namespace KarstNSim {
 		// Whatever the original dimensions of the Box are, they are transformed during the algorithm and back-transformed at the end.
 		std::vector<int> active_list({ 1 });
 		bool init_pt_in_grid = false;
-		Vector3  pos_init;
+		Vector3 pos_init;
 		int64_t flattened_index = 0;
 		int64_t converted_flat_index = 0;
+		const int max_attempts = 100000;
+		int attempt_count = 0;
 		if (use_density_property) {
-			while (!init_pt_in_grid) {
+			while (!init_pt_in_grid && attempt_count < max_attempts) {
 				pos_init.x = generateRandomFloat(0, dim1);
 				pos_init.y = generateRandomFloat(0, dim2);
 				pos_init.z = generateRandomFloat(0, dim3); // first random point of index 1
@@ -112,10 +114,14 @@ namespace KarstNSim {
 				if (propdensity[converted_flat_index] > 0 && CheckBelowSurf(real_pt, topo_surface, centers2D)) { // we make sure here that the 1st random point is indeed a) in the karstifiable zone (propdensity >0) and b) below topography
 					init_pt_in_grid = true;
 				}
+				attempt_count++;
+			}
+			if (!init_pt_in_grid) {
+				throw std::runtime_error("Failed to find a valid starting point in the grid after maximum attempts.");
 			}
 		}
 		else {
-			while (!init_pt_in_grid) {
+			while (!init_pt_in_grid && attempt_count < max_attempts) {
 				pos_init.x = generateRandomFloat(0, dim1);
 				pos_init.y = generateRandomFloat(0, dim2);
 				pos_init.z = generateRandomFloat(0, dim3);
@@ -126,6 +132,10 @@ namespace KarstNSim {
 				if (CheckBelowSurf(real_pt, topo_surface, centers2D)) { // we make sure here that the 1st random point is indeed below topography
 					init_pt_in_grid = true;
 				}
+				attempt_count++;
+			}
+			if (!init_pt_in_grid) {
+				throw std::runtime_error("Failed to find a valid starting point below topography after maximum attempts.");
 			}
 		}
 

--- a/KarstNSim/src/graph_operations.cpp
+++ b/KarstNSim/src/graph_operations.cpp
@@ -111,7 +111,8 @@ namespace KarstNSim {
 				real_pt.x = min.x + (pos_init.x * u.x / dim1 + pos_init.y * v.x / dim2 + pos_init.z * w.x / dim3);
 				real_pt.y = min.y + (pos_init.x * u.y / dim1 + pos_init.y * v.y / dim2 + pos_init.z * w.y / dim3);
 				real_pt.z = min.z + (pos_init.x * u.z / dim1 + pos_init.y * v.z / dim2 + pos_init.z * w.z / dim3);
-				if (propdensity[converted_flat_index] > 0 && CheckBelowSurf(real_pt, topo_surface, centers2D)) { // we make sure here that the 1st random point is indeed a) in the karstifiable zone (propdensity >0) and b) below topography
+				// we make sure here that the 1st random point is indeed a) in the karstifiable zone (propdensity >0) and b) below topography
+				if (propdensity[converted_flat_index] > 0 && CheckBelowSurf(real_pt, topo_surface, centers2D)) {
 					init_pt_in_grid = true;
 				}
 				attempt_count++;
@@ -138,6 +139,8 @@ namespace KarstNSim {
 				throw std::runtime_error("Failed to find a valid starting point below topography after maximum attempts.");
 			}
 		}
+
+		std::cout << " * Will start Poisson sampling with r_min = " << r_min << " and initial point at (" << pos_init.x << "," << pos_init.y << "," << pos_init.z << ")" << std::endl;
 
 		Vector3 new_p; // add the first point to the samples list
 		new_p.x = min.x + (pos_init.x * u.x / dim1 + pos_init.y * v.x / dim2 + pos_init.z * w.x / dim3);
@@ -603,15 +606,18 @@ namespace KarstNSim {
 				new_pt.z = sampling_points[i].z;
 				samples.push_back(new_pt);
 			}
+			std::cout << " * Using " << samples.size() << " user-defined sampling points." << std::endl;
 		}
 
 		// 1.2b else we sample them with modified Dwork poisson sphere sampling
 		else {
 			SampleSpaceDwork(box, use_density_property, k_pts, propdensity, topo_surface);
+			std::cout << " * Using " << samples.size() << " automatically sampled points." << std::endl;
 		}
 
 		// 1.3 remove points sampled inside the "no-karst" spheres
 		// /!\ NEVER make a no-karst sphere and a keypoint intersect (makes code crash)
+		size_t old_sample_size = samples.size();
 		PointCloud centers_sampling_pts(samples);
 		std::vector<Neighbour> all_candidates;
 		for (int sphere = 0; sphere < params.spheres.size(); sphere++) {
@@ -643,8 +649,10 @@ namespace KarstNSim {
 			}
 			remove_neighbors(nodes_on_wt_surfaces[wt], all_candidates_wt);
 		}
+		std::cout << " * Removed " << old_sample_size - samples.size() << " points from the sampling set because they were inside no-karst spheres. " << std::endl;
 
 		// 1.4 Add inception surface points to samples
+		old_sample_size = samples.size();
 		for (int i = 0; i < nodes_on_inception_surfaces.size(); i++) {
 			float value_itr = 1.;
 			if (!use_sampling_points && use_density_property) {
@@ -660,8 +668,10 @@ namespace KarstNSim {
 				process_node_in_samples(nodes_on_inception_surfaces[i], on_surf_flags_idx[0]);
 			}
 		}
+		std::cout << " * Added " << samples.size() - old_sample_size << " points from the inception surfaces to the sampling set. " << std::endl;
 
 		// 1.5 Add water table points to samples
+		old_sample_size = samples.size();
 		for (int i = 0; i < keypts.size(); i++) { // first the keypoints
 			if (keypts[i].type == KeyPointType::Spring) {
 				auto it = std::find(samples.begin(), samples.end(), keypts[i].p);
@@ -687,8 +697,10 @@ namespace KarstNSim {
 				}
 			}
 		}
+		std::cout << " * Added " << samples.size() - old_sample_size << " points from the water table surfaces to the sampling set. " << std::endl;
 
 		// 1.6 Add previously simulated karst networks samples
+		old_sample_size = samples.size();
 		for (int i = 0; i < params.PtsOldGraph.size(); i++) {
 			std::vector<int> idx_i;
 			for (int j = 0; j < 2; j++) { // =2 (start and end points of each segment of the old graph)
@@ -696,6 +708,7 @@ namespace KarstNSim {
 			}
 			params.IdxOldGraph.set_row(i, idx_i);
 		}
+		std::cout << " * Added " << samples.size() - old_sample_size << " points from the previously simulated karst networks to the sampling set. " << std::endl;
 		//IdxOldGraph = params.IdxOldGraph;
 		std::vector<std::string> noise_prop_name;
 		if (params.use_noise) {

--- a/KarstNSim/src/karstic_network.cpp
+++ b/KarstNSim/src/karstic_network.cpp
@@ -598,9 +598,11 @@ namespace KarstNSim {
 		}
 	}
 
-	float KarsticNetwork::run_simulation(const bool& sections_simulation_only, const bool& create_nghb_graph, const bool& create_nghb_graph_property, const bool& use_amplification, const bool& use_sampling_points,
-		const float& fraction_karst_perm, const float& fraction_old_karst_perm, const float& max_inception_surface_distance, std::vector<Vector3>* sampling_points, const bool& create_vset_sampling,
-		const bool& use_density_property, const int& k_pts, const std::vector<float>& propdensity, const std::vector<float>& propikp) {
+	float KarsticNetwork::run_simulation(const bool& sections_simulation_only, const bool& create_nghb_graph, const bool& create_nghb_graph_property,
+		const bool& create_solved_connectivity_matrix, const bool& use_amplification, const bool& use_sampling_points,
+		const float& fraction_karst_perm, const float& fraction_old_karst_perm, const float& max_inception_surface_distance,
+		std::vector<Vector3>* sampling_points, const bool& create_vset_sampling, const bool& use_density_property,
+		const int& k_pts, const std::vector<float>& propdensity, const std::vector<float>& propikp) {
 
 			params.scenename = karstic_network_name;
 		// Cost due to distance
@@ -627,7 +629,7 @@ namespace KarstNSim {
 			std::vector<std::vector<float>> karst_paths_costs;
 			std::vector<std::vector<char>> karst_paths_vadose_flag;
 			std::vector<int> springidxFinal;
-			graph.ComputeKarsticSkeleton(keypts, fraction_karst_perm, karst_paths, karst_paths_costs, karst_paths_vadose_flag, springidxFinal);
+			graph.ComputeKarsticSkeleton(keypts, fraction_karst_perm, karst_paths, karst_paths_costs, karst_paths_vadose_flag, springidxFinal, create_solved_connectivity_matrix);
 
 			if (!karst_paths.empty()) { // if a network was successfully computed
 

--- a/KarstNSim/src/karstic_network.cpp
+++ b/KarstNSim/src/karstic_network.cpp
@@ -598,123 +598,119 @@ namespace KarstNSim {
 		}
 	}
 
-	float KarsticNetwork::run_simulation(const bool& sections_simulation_only, const bool& create_nghb_graph, const bool& create_nghb_graph_property,
-		const bool& create_solved_connectivity_matrix, const bool& use_amplification, const bool& use_sampling_points,
-		const float& fraction_karst_perm, const float& fraction_old_karst_perm, const float& max_inception_surface_distance,
-		std::vector<Vector3>* sampling_points, const bool& create_vset_sampling, const bool& use_density_property,
-		const int& k_pts, const std::vector<float>& propdensity, const std::vector<float>& propikp) {
-
-			params.scenename = karstic_network_name;
-		// Cost due to distance
+	std::optional<KarstNetworkResult> KarsticNetwork::run_simulation(
+		const bool &sections_simulation_only, const bool &create_nghb_graph,
+		const bool &create_nghb_graph_property,
+		const bool &create_solved_connectivity_matrix,
+		const bool &use_amplification, const bool &use_sampling_points,
+		const float &fraction_karst_perm, const float &fraction_old_karst_perm,
+		const float &max_inception_surface_distance,
+		std::vector<Vector3> *sampling_points, const bool &create_vset_sampling,
+		const bool &use_density_property, const int &k_pts,
+		const std::vector<float> &propdensity, const std::vector<float> &propikp
+	) {
+		params.scenename = karstic_network_name;
 		const clock_t time1 = clock();
-		float time_needed = 0.0f;
 
 		if (is_simulation_parametrized) { // full simulation
 
 			// Compute 3D cost graph
 
 			GraphOperations graph;
-			graph.InitializeCostGraph(create_nghb_graph, create_nghb_graph_property, keypts, params, nodes_on_inception_surfaces, nodes_on_wt_surfaces,
-				inception_horizons, water_tables, use_sampling_points, box, max_inception_surface_distance, sampling_points, create_vset_sampling,
-				use_density_property, k_pts, fraction_old_karst_perm, propdensity, propikp, topo_surface_);
+			graph.InitializeCostGraph(
+				create_nghb_graph, create_nghb_graph_property, keypts, params,
+				nodes_on_inception_surfaces, nodes_on_wt_surfaces, inception_horizons,
+				water_tables, use_sampling_points, box, max_inception_surface_distance,
+				sampling_points, create_vset_sampling, use_density_property, k_pts,
+				fraction_old_karst_perm, propdensity, propikp, topo_surface_);
 			const clock_t time2 = clock();
 
-			std::cout << "Cost graph initialized ("
-				<< std::fixed << std::setprecision(3)
-				<< float(time2 - time1) / CLOCKS_PER_SEC << " s)" << std::endl;
+			std::cout << "Cost graph initialized (" << std::fixed
+					<< std::setprecision(3) << float(time2 - time1) / CLOCKS_PER_SEC
+					<< " s)" << std::endl;
 
-				// Compute karstic skeleton
-
-				std::vector<std::vector<int>> karst_paths;
+			// Compute karstic skeleton
+			std::vector<std::vector<int>> karst_paths;
 			std::vector<std::vector<float>> karst_paths_costs;
 			std::vector<std::vector<char>> karst_paths_vadose_flag;
 			std::vector<int> springidxFinal;
-			graph.ComputeKarsticSkeleton(keypts, fraction_karst_perm, karst_paths, karst_paths_costs, karst_paths_vadose_flag, springidxFinal, create_solved_connectivity_matrix);
 
-			if (!karst_paths.empty()) { // if a network was successfully computed
+			graph.ComputeKarsticSkeleton(keypts, fraction_karst_perm, karst_paths,
+										karst_paths_costs, karst_paths_vadose_flag,
+										springidxFinal,
+										create_solved_connectivity_matrix);
 
-				// Build karstic skeleton structure
-				KarsticSkeleton skel(&graph, karst_paths, karst_paths_costs, karst_paths_vadose_flag, springidxFinal);
+			if (karst_paths.empty()) {
+				std::cout << "No path found between inlets and outlets with the "
+							"current parameters."
+							<< std::endl;
+				return std::nullopt; // no path found
+			}
 
-				const clock_t time3 = clock();
+			// Build karstic skeleton structure
+			KarsticSkeleton skel(&graph, karst_paths, karst_paths_costs,
+								karst_paths_vadose_flag, springidxFinal);
 
-				std::cout << "Skeleton computed ("
-					<< std::fixed << std::setprecision(3)
+			const clock_t time3 = clock();
+
+			std::cout << "Skeleton computed (" << std::fixed << std::setprecision(3)
 					<< float(time3 - time2) / CLOCKS_PER_SEC << " s)" << std::endl;
 
+			// Network preparation
+			skel.detect_intersection_points(karst_paths);
+			skel.update_branch_ID(karst_paths);
 
-					// Network preparation
-					skel.detect_intersection_points(karst_paths);
-				skel.update_branch_ID(karst_paths);
+			// Procedural amplification with deadend nodes
+			const clock_t time4 = clock();
+			if (use_deadend_pts_) {
+				skel.amplify_deadend(&graph, max_distance_of_deadend_pts_, nb_deadend_points_, params);
+			}
+			const clock_t time5 = clock();
 
-				// Procedural amplification with deadend nodes
-				const clock_t time4 = clock();
-				if (use_deadend_pts_) {
-					skel.amplify_deadend(&graph, max_distance_of_deadend_pts_, nb_deadend_points_, params);
+			if (use_deadend_pts_) {
+				std::cout << "Network amplified with deadend points (" << std::fixed
+							<< std::setprecision(3) << float(time5 - time4) / CLOCKS_PER_SEC
+							<< " s)" << std::endl;
+			}
+
+			// Amplification
+			if (use_amplification) {
+				if (params.use_noise && !params.use_noise_on_all) {
+					graph.add_noise();
 				}
-				const clock_t time5 = clock();
+				std::pair<float, float> result = skel.amplify_noise(&graph, params);
+				const clock_t time5bis = clock();
+			}
 
-				if (use_deadend_pts_) {
-					std::cout << "Network amplified with deadend points ("
-						<< std::fixed << std::setprecision(3)
-						<< float(time5 - time4) / CLOCKS_PER_SEC << " s)" << std::endl;
-				}
+			const clock_t time6 = clock();
+			skel.detect_intersection_points(karst_paths);
+			skel.update_branch_ID(karst_paths);
 
-					// Amplification
-					if (use_amplification) {
-						if (params.use_noise && !params.use_noise_on_all) {
-							graph.add_noise();
-						}
-						std::pair<float, float> result = skel.amplify_noise(&graph, params);
-						const clock_t time5bis = clock();
-					}
+			create_sections(skel);
+			const clock_t time7 = clock();
 
-				const clock_t time6 = clock();
-				skel.detect_intersection_points(karst_paths);
-				skel.update_branch_ID(karst_paths);
+			std::cout << "Conduits sections generated (" << std::fixed
+					<< std::setprecision(3) << float(time7 - time6) / CLOCKS_PER_SEC
+					<< " s)" << std::endl;
 
-				create_sections(skel);
-				const clock_t time7 = clock();
+			// save network
+			auto res = skel.get_result(params, karstic_network_name);
+			const clock_t time8 = clock();
 
-				std::cout << "Conduits sections generated ("
-					<< std::fixed << std::setprecision(3)
-					<< float(time7 - time6) / CLOCKS_PER_SEC << " s)" << std::endl;
-
-				// save network
-				skel.create_line(params, karstic_network_name);
-
-				const clock_t time8 = clock();
-
-				std::cout << "Karst network saved ("
-					<< std::fixed << std::setprecision(3)
+			std::cout << "Karst network saved (" << std::fixed << std::setprecision(3)
 					<< float(time8 - time7) / CLOCKS_PER_SEC << " s)" << std::endl;
 
-
-				const clock_t time_end = clock();
-				time_needed = float(time_end - time1) / CLOCKS_PER_SEC;
-			}
-			else {
-			}
-
-		}
-		else if (sections_simulation_only) { // only generate sections
+			return res;
+		} else if (sections_simulation_only) { // only generate sections
 			std::vector<std::vector<float>> costs_graph(params.PtsOldGraph.size(), std::vector<float>(2, 0.0)); // dummy vector
 			std::vector<std::vector<char>> vadoseflags_graph(params.PtsOldGraph.size(), std::vector<char>(2, false)); // dummy vector
 			std::vector<int> springidx(params.PtsOldGraph.size(), 1);
 			KarsticSkeleton skel(params.PtsOldGraph, costs_graph, vadoseflags_graph, springidx);
 
-			const clock_t time5 = clock();
-
 			create_sections(skel);
-
-			const clock_t time6 = clock();
-
-				// save network
-				skel.create_line(params, karstic_network_name);
-
-			const clock_t time7 = clock();
+			return skel.get_result(params, karstic_network_name);
 		}
-		return time_needed;
+		return std::nullopt;
 	}
 
 	void KarsticNetwork::set_save_directory(const std::string& repertory) {

--- a/KarstNSim/src/karstic_network.cpp
+++ b/KarstNSim/src/karstic_network.cpp
@@ -12,8 +12,8 @@ If you use this code, please cite : Gouy et al., 2024, Journal of Hydrology.
 
 namespace KarstNSim {
 
-	KarsticNetwork::KarsticNetwork(const std::string& karstic_network_name, Box* box, GeologicalParameters& params,
-		const std::vector<KeyPoint>& keypts, std::vector<Surface>* water_tables) :
+	KarsticNetwork::KarsticNetwork(const std::string& karstic_network_name, const Box& box, GeologicalParameters& params,
+		const std::vector<KeyPoint>& keypts, const std::vector<Surface>& water_tables) :
 		karstic_network_name(karstic_network_name), box(box), params(params), keypts(keypts), water_tables(water_tables) {};
 
 	void KarsticNetwork::set_simulation_parameters(const int& nghb_count, const bool& use_max_nghb_radius, const float& nghb_radius, const float& poisson_radius, const float& gamma, const bool& multiply_costs, const bool& vadose_cohesion) {
@@ -30,7 +30,7 @@ namespace KarstNSim {
 		set_domain_geometry();
 	}
 
-	void KarsticNetwork::set_sinks(const std::vector<Vector3>* sinks, const std::vector<int>& propsinksindex, const std::vector<int>& propsinksorder, bool use_sinks_radius, const std::vector<float>& propsinksradius) {
+	void KarsticNetwork::set_sinks(const std::vector<Vector3>& sinks, const std::vector<int>& propsinksindex, const std::vector<int>& propsinksorder, bool use_sinks_radius, const std::vector<float>& propsinksradius) {
 
 		//std::vector<int> propsinksindex = get_gobj_property_karstnetwork(sinks, sinks_index, int(sinks->size()));
 		//std::vector<int> propsinksorder = get_gobj_property_karstnetwork(sinks, sinks_order, int(sinks->size()));
@@ -47,7 +47,7 @@ namespace KarstNSim {
 			std::vector<int> propsinks_iter;
 			std::vector<int> propsinks_iter_index;
 			std::vector<int> indexes;
-			for (int i = 0; i < sinks->size(); i++) {
+			for (int i = 0; i < sinks.size(); i++) {
 				if (propsinksorder[i] == scanning_order) {
 					propsinks_iter.push_back(i);
 					propsinks_iter_index.push_back(propsinksindex[i]);
@@ -61,8 +61,8 @@ namespace KarstNSim {
 			reorder(propsinks_iter_index, indexes);
 			for (int i = 0; i < int(propsinks_iter.size()); i++) {
 				params.sinks_index.push_back(propsinks_iter_index[i]); // insert shuffled vector of indices of sinks of order i
-				this->keypts.emplace_back(sinks->at(propsinks_iter[i]), KeyPointType::Sink);
-				this->pt_sink.push_back(sinks->at(propsinks_iter[i]));
+				this->keypts.emplace_back(sinks.at(propsinks_iter[i]), KeyPointType::Sink);
+				this->pt_sink.push_back(sinks.at(propsinks_iter[i]));
 
 				if (use_sinks_radius_) {
 					propsinksradius_.push_back({ propsinksradius[propsinks_iter[i]], int(keypts.size() - 1) });
@@ -72,22 +72,22 @@ namespace KarstNSim {
 		}
 	}
 
-	void KarsticNetwork::set_springs(const std::vector<Vector3>* springs, const std::vector<int>& propspringsindex, const bool& allow_single_outlet_connection, bool use_springs_radius, const std::vector<float>& propspringsradius, const std::vector<int>& propspringswtindex) {
+	void KarsticNetwork::set_springs(const std::vector<Vector3>& springs, const std::vector<int>& propspringsindex, const bool& allow_single_outlet_connection, bool use_springs_radius, const std::vector<float>& propspringsradius, const std::vector<int>& propspringswtindex) {
 
 		params.allow_single_outlet = allow_single_outlet_connection;
-		params.nb_springs = int(springs->size());
+		params.nb_springs = int(springs.size());
 		//std::vector<int> propspringsindex = get_gobj_property_karstnetwork(springs, springs_index, params.nb_springs);
 
 		// get all z values for the springs
 		use_springs_radius_ = use_springs_radius;
 
-		for (int i = 0; i < springs->size(); i++)
+		for (int i = 0; i < springs.size(); i++)
 		{
 			int index_for_i = int(std::find(propspringsindex.begin(), propspringsindex.end(), i + 1) - propspringsindex.begin());
 
-			this->keypts.emplace_back(springs->at(index_for_i), KeyPointType::Spring, propspringswtindex[index_for_i]);
-			params.z_list.push_back({ springs->at(index_for_i).z,  int(keypts.size() - 1) });
-			this->pt_spring.push_back(springs->at(index_for_i));
+			this->keypts.emplace_back(springs.at(index_for_i), KeyPointType::Spring, propspringswtindex[index_for_i]);
+			params.z_list.push_back({ springs.at(index_for_i).z,  int(keypts.size() - 1) });
+			this->pt_spring.push_back(springs.at(index_for_i));
 			params.propspringswtindex.push_back({ static_cast<float>(propspringswtindex[index_for_i]), int(keypts.size() - 1) });
 			if (use_springs_radius_) {
 				propspringsradius_.push_back({ propspringsradius[index_for_i], int(keypts.size() - 1) });
@@ -95,13 +95,13 @@ namespace KarstNSim {
 		}
 	}
 
-	void KarsticNetwork::set_waypoints(const std::vector<Vector3>* waypoints,
+	void KarsticNetwork::set_waypoints(const std::vector<Vector3>& waypoints,
 		bool use_waypoints_radius,
 		const std::vector<float>& propwaypointsradius,
 		const std::vector<float>& propwaypointsimpactradius,
 		float waypoints_weight)
 	{
-		const int n_pts = static_cast<int>(waypoints->size());
+		const int n_pts = static_cast<int>(waypoints.size());
 
 		// Mandatory: impact radius size must match
 		if (static_cast<int>(propwaypointsimpactradius.size()) != n_pts) {
@@ -120,7 +120,7 @@ namespace KarstNSim {
 		params.waypoints_weight = waypoints_weight;
 
 		for (int i = 0; i < n_pts; ++i) {
-			this->keypts.emplace_back(waypoints->at(i), KeyPointType::Waypoint);
+			this->keypts.emplace_back(waypoints[i], KeyPointType::Waypoint);
 			if (use_waypoints_radius_) {
 				propwaypointsradius_.push_back({ propwaypointsradius[i], int(keypts.size() - 1) });
 			}
@@ -135,18 +135,18 @@ namespace KarstNSim {
 	//	}
 	//}
 
-	void KarsticNetwork::set_previous_networks(const std::vector<Line>* previous_networks) {
+	void KarsticNetwork::set_previous_networks(const std::vector<Line>& previous_networks) {
 
 		int count_total_nb_segs = 0;
-		for (int i = 0; i < previous_networks->size(); i++) {
-			Line Line_i = previous_networks->at(i);
+		for (int i = 0; i < previous_networks.size(); i++) {
+			Line Line_i = previous_networks.at(i);
 			count_total_nb_segs += int(Line_i.get_nb_segs());
 		}
 		params.PtsOldGraph.resize(count_total_nb_segs, 2); // vector of all segments of the old graph, represented each with their start and end point
 		params.IdxOldGraph.resize(count_total_nb_segs, 2); // vector of all point of the old graph, each represented by its index in the samples object of GraphOperations
 		count_total_nb_segs = 0;
-		for (int i = 0; i < previous_networks->size(); i++) {
-			Line Line_i = previous_networks->at(i);
+		for (int i = 0; i < previous_networks.size(); i++) {
+			Line Line_i = previous_networks.at(i);
 			int segsize_i = int(Line_i.get_nb_segs());
 			for (int j = 0; j < segsize_i; j++)
 			{
@@ -164,21 +164,21 @@ namespace KarstNSim {
 		max_distance_of_deadend_pts_ = max_distance_of_deadend_pts;
 	}
 
-	void KarsticNetwork::set_inception_surfaces_sampling(const std::string& network_name, std::vector<Surface>* surfaces_used_to_densify, const int& refine_surface_sampling, const bool& create_vset_sampling) {
-		params.nb_inception_surf = int(surfaces_used_to_densify->size());
+	void KarsticNetwork::set_inception_surfaces_sampling(const std::string& network_name, const std::vector<Surface>& surfaces_used_to_densify, const int& refine_surface_sampling, const bool& create_vset_sampling) {
+		params.nb_inception_surf = int(surfaces_used_to_densify.size());
 		KarstNSim::surface_sampling::multiple_surface_sampling(params.directoryname, network_name, box, surfaces_used_to_densify, nodes_on_inception_surfaces, refine_surface_sampling, create_vset_sampling);
 	}
 
-	void KarsticNetwork::set_wt_surfaces_sampling(const std::string& network_name, std::vector<Surface>* surfaces_used_to_densify, const int& refine_surface_sampling) {
+	void KarsticNetwork::set_wt_surfaces_sampling(const std::string& network_name, const std::vector<Surface>& surfaces_used_to_densify, const int& refine_surface_sampling) {
 
-		nodes_on_wt_surfaces.resize(surfaces_used_to_densify->size()); // Resize nodes_on_wt_surfaces to match the number of water tables
-		params.nb_wt = surfaces_used_to_densify->size();
+		nodes_on_wt_surfaces.resize(surfaces_used_to_densify.size()); // Resize nodes_on_wt_surfaces to match the number of water tables
+		params.nb_wt = surfaces_used_to_densify.size();
 
-		for (int i = 0; i < surfaces_used_to_densify->size(); i++) {
+		for (int i = 0; i < surfaces_used_to_densify.size(); i++) {
 			std::vector<Surface> wt_surface;
-			wt_surface.push_back(surfaces_used_to_densify->at(i));
+			wt_surface.push_back(surfaces_used_to_densify.at(i));
 			std::vector<Vector3> nodes_on_wt_surface;
-			KarstNSim::surface_sampling::multiple_surface_sampling(params.directoryname, network_name, box, &wt_surface, nodes_on_wt_surface, refine_surface_sampling, false);
+			KarstNSim::surface_sampling::multiple_surface_sampling(params.directoryname, network_name, box, wt_surface, nodes_on_wt_surface, refine_surface_sampling, false);
 			nodes_on_wt_surfaces[i] = nodes_on_wt_surface;
 		}
 	}
@@ -195,29 +195,29 @@ namespace KarstNSim {
 		}
 		std::string full_name = karstic_network_name + "_box.txt";
 		std::string full_dir_name = params.directoryname + "/outputs";
-		save_box(full_name, full_dir_name, *box, property_names, properties);
+		save_box(full_name, full_dir_name, box, property_names, properties);
 	}
 
-	void KarsticNetwork::set_topo_surface(Surface* topo_surface) {
+	void KarsticNetwork::set_topo_surface(const Surface& topo_surface) {
 		this->topo_surface_ = topo_surface;
 	}
 
-	void KarsticNetwork::set_inception_horizons_parameters(std::vector<Surface>* inception_horizons_list, const float& inception_horizon_constraint_weight) {
+	void KarsticNetwork::set_inception_horizons_parameters(const std::vector<Surface>& inception_horizons_list, const float& inception_horizon_constraint_weight) {
 		this->inception_horizons = inception_horizons_list;
 		params.horizonCost = CostTerm(true, inception_horizon_constraint_weight);
 	}
 
-	void KarsticNetwork::set_ghost_rocks(const Box& grid, std::vector<float>& ikp, Line* alteration_lines, const bool& interpolate_lines, const float& ghostrock_max_vertical_size, const bool& use_max_depth_constraint, const float& ghost_rock_weight, Surface* max_depth_horizon, const float& ghostrock_width) {
+	void KarsticNetwork::set_ghost_rocks(const Box& grid, std::vector<float>& ikp, const Line& alteration_lines, const bool& interpolate_lines, const float& ghostrock_max_vertical_size, const bool& use_max_depth_constraint, const float& ghost_rock_weight, Surface* max_depth_horizon, const float& ghostrock_width) {
 
 		params.use_ghost_rocks = true;
 		params.length = ghostrock_max_vertical_size;
 		params.width = ghostrock_width;
-		params.polyline = *alteration_lines;
+		params.polyline = alteration_lines;
 		params.use_max_depth_constraint = use_max_depth_constraint;
 		params.substratum_surf = *max_depth_horizon;
 
 		// modify "ikp" object with ghostrocks ("paint" it). Note that density property is NOT changed, hence passed as const ref
-		paint_KP_with_ghostrocks(grid, ikp, ghostrock_max_vertical_size, ghostrock_width, *alteration_lines, use_max_depth_constraint, *max_depth_horizon, ghost_rock_weight);
+		paint_KP_with_ghostrocks(grid, ikp, ghostrock_max_vertical_size, ghostrock_width, alteration_lines, use_max_depth_constraint, *max_depth_horizon, ghost_rock_weight);
 	}
 
 	void KarsticNetwork::disable_inception_horizon() {
@@ -228,9 +228,9 @@ namespace KarstNSim {
 		params.karstificationCost = CostTerm(true, karstification_potential_weight);
 	}
 
-	void KarsticNetwork::set_fracture_constraint_parameters(const std::vector<float>* fracture_families_orientations, const std::vector<float>* fracture_families_tolerance, const float& fracture_constraint_weight) {
-		params.fractures_orientations = *fracture_families_orientations;
-		params.fractures_tolerances = *fracture_families_tolerance;
+	void KarsticNetwork::set_fracture_constraint_parameters(const std::vector<float>& fracture_families_orientations, const std::vector<float>& fracture_families_tolerance, const float& fracture_constraint_weight) {
+		params.fractures_orientations = fracture_families_orientations;
+		params.fractures_tolerances = fracture_families_tolerance;
 		params.fractureCost = CostTerm(true, fracture_constraint_weight);
 	}
 
@@ -238,11 +238,12 @@ namespace KarstNSim {
 		params.fractureCost = CostTerm(false, 0.0);
 	}
 
-	void KarsticNetwork::set_no_karst_spheres_parameters(const std::vector<Vector3>* sphere_centers,
+	void KarsticNetwork::set_no_karst_spheres_parameters(const std::vector<Vector3>& sphere_centers,
 		const std::vector<float>& sphere_radius)
 	{
 		// --- Defensive checks to prevent crashes and undefined behavior ---
-		if (sphere_centers == nullptr || sphere_centers->empty()) {
+		if (sphere_centers.empty()) {
+			std::cout << "WARNING: no 'no-karst' spheres provided; skipping spheres setup." << std::endl;
 			return;
 		}
 
@@ -251,16 +252,16 @@ namespace KarstNSim {
 		}
 
 		const bool one_radius_for_all = (sphere_radius.size() == 1);
-		const bool per_sphere_radius = (sphere_radius.size() == sphere_centers->size());
+		const bool per_sphere_radius = (sphere_radius.size() == sphere_centers.size());
 
 		if (!one_radius_for_all && !per_sphere_radius) {
 			std::cout << "WARNING: sphere_radius size (" << sphere_radius.size()
-				<< ") does not match 1 or number of centers (" << sphere_centers->size()
+				<< ") does not match 1 or number of centers (" << sphere_centers.size()
 				<< "). Using the first radius for all spheres as fallback." << std::endl;
 		}
 
 		int added = 0;
-		for (int i = 0; i < static_cast<int>(sphere_centers->size()); ++i) {
+		for (int i = 0; i < static_cast<int>(sphere_centers.size()); ++i) {
 			float r = 0.0f;
 
 			if (one_radius_for_all) {
@@ -280,7 +281,7 @@ namespace KarstNSim {
 				continue;
 			}
 
-			params.spheres.push_back(Sphere(sphere_centers->at(i), r));
+			params.spheres.push_back(Sphere(sphere_centers.at(i), r));
 			++added;
 		}
 	}
@@ -288,8 +289,8 @@ namespace KarstNSim {
 
 	void KarsticNetwork::set_domain_geometry() {
 
-		const Vector3& min_pt = box->get_basis();
-		const Vector3& max_pt = box->get_end();
+		const Vector3& min_pt = box.get_basis();
+		const Vector3& max_pt = box.get_end();
 
 		float delta_y = max_pt.y - min_pt.y;
 		float delta_x = max_pt.x - min_pt.x;
@@ -352,13 +353,12 @@ namespace KarstNSim {
 		outfile.close();
 	}
 
-	void KarsticNetwork::read_connectivity_matrix(const std::string& simulation_input_dir, const std::vector<Vector3>* sinks, const std::vector<Vector3>* springs) {
+	void KarsticNetwork::read_connectivity_matrix(const std::string& simulation_input_dir, const std::vector<Vector3>& sinks, const std::vector<Vector3>& springs) {
 
-		//std::string connectivity_matrix_path = params.directoryname + "/Input_files/connectivity_matrix.txt";
 		const std::string connectivity_matrix_path = simulation_input_dir + "/connectivity_matrix.txt";
 
-		int nb_sinks = static_cast<int>(sinks->size());
-		int nb_springs = static_cast<int>(springs->size());
+		int nb_sinks = static_cast<int>(sinks.size());
+		int nb_springs = static_cast<int>(springs.size());
 
 		// Check if the file exists, if not, create it
 
@@ -521,14 +521,14 @@ namespace KarstNSim {
 		}
 	}
 
-	void KarsticNetwork::run_simulation_properties(KarsticSkeleton& skel, Line* alteration_lines, const bool& use_ghost_rocks, const float& ghostrock_max_vertical_size, const bool& use_max_depth_constraint, Surface* max_depth_horizon, const float& ghostrock_width) {
+	void KarsticNetwork::run_simulation_properties(KarsticSkeleton& skel, const Line& alteration_lines, const bool& use_ghost_rocks, const float& ghostrock_max_vertical_size, const bool& use_max_depth_constraint, const Surface& max_depth_horizon, const float& ghostrock_width) {
 
 		params.use_ghost_rocks = use_ghost_rocks;
 		params.length = ghostrock_max_vertical_size;
 		params.width = ghostrock_width;
-		params.polyline = *alteration_lines;
+		params.polyline = alteration_lines;
 		params.use_max_depth_constraint = use_max_depth_constraint;
-		params.substratum_surf = *max_depth_horizon;
+		params.substratum_surf = max_depth_horizon;
 
 		skel.prepare_graph(); // removes duplicates, and changes format so that each node is connected to all of its neighbors (not the case at base necesarily)
 		skel.update_branch_ID(); // create branch id property on the skeleton nodes (-1 if intersection, branch index >=1 otherwise)
@@ -605,7 +605,7 @@ namespace KarstNSim {
 		const bool &use_amplification, const bool &use_sampling_points,
 		const float &fraction_karst_perm, const float &fraction_old_karst_perm,
 		const float &max_inception_surface_distance,
-		std::vector<Vector3> *sampling_points, const bool &create_vset_sampling,
+		const std::vector<Vector3> &sampling_points, const bool &create_vset_sampling,
 		const bool &use_density_property, const int &k_pts,
 		const std::vector<float> &propdensity, const std::vector<float> &propikp
 	) {

--- a/KarstNSim/src/karstic_skeleton.cpp
+++ b/KarstNSim/src/karstic_skeleton.cpp
@@ -949,107 +949,53 @@ namespace KarstNSim {
 		}
 	}
 
-	void KarsticSkeleton::create_line(const GeologicalParameters& geologicalparams, std::string network_name) const
+	KarstNetworkResult KarsticSkeleton::get_result(const GeologicalParameters& geologicalparams, std::string network_name) const
 	{
 
-		std::vector<Segment> nghb_graph_line;
-		std::vector<float> list_cost;
-		std::vector<float> list_vadose;
-		std::vector<float> list_eq_radius;
-		std::vector<int> list_branch_id;
-		//std::vector<float> list_branch_dist; //debugging
+		KarstNetworkResult result;
+
+		std::vector<int> list_new_branch_id;
+		std::vector<int> used_id = { 0 };
+		std::vector<std::vector<int>> seen_br_id = { nodes[0].branch_id_ascend };
 
 		for (int i = 0; i < nodes.size(); i++) {
 			for (int j = 0; j < nodes[i].connections.size(); j++) {
+				auto it = find(seen_br_id.begin(), seen_br_id.end(), nodes[nodes[i].connections[j].destindex].branch_id_ascend);
 
 				float epsilon = 1e-10;
 				// Find the index of the first element in cost that is not effectively zero (it corresponds to the spring index to which the path leads to)
 				int index_spring = std::distance(nodes[i].cost.begin(), std::find_if(nodes[i].cost.begin(), nodes[i].cost.end(),
 					[epsilon](float c) { return std::fabs(c) > epsilon; }));
 
-				list_cost.push_back(float(nodes[i].cost[index_spring]));
-				list_cost.push_back(float(nodes[nodes[i].connections[j].destindex].cost[index_spring]));
+				ResultPoint start, end;
+				start.p = nodes[i].p;
+				start.cost = float(nodes[i].cost[index_spring]);
+				start.equivalent_radius = float(nodes[i].eq_radius);
+				start.vadose_flag = float(nodes[i].vadose[index_spring]);
 
-				list_eq_radius.push_back(float(nodes[i].eq_radius));
-				list_eq_radius.push_back(float(nodes[nodes[i].connections[j].destindex].eq_radius));
+				end.p = nodes[nodes[i].connections[j].destindex].p;
+				end.cost = float(nodes[nodes[i].connections[j].destindex].cost[index_spring]);
+				end.equivalent_radius = float(nodes[nodes[i].connections[j].destindex].eq_radius);
+				end.vadose_flag = float(nodes[nodes[i].connections[j].destindex].vadose[index_spring]);
 
-				list_branch_id.push_back(nodes[i].branch_id);
-				list_branch_id.push_back(nodes[nodes[i].connections[j].destindex].branch_id);
-
-				list_vadose.push_back(float(nodes[i].vadose[index_spring]));
-				list_vadose.push_back(float(nodes[nodes[i].connections[j].destindex].vadose[index_spring]));
-
-				//list_branch_dist.push_back(float(nodes[i].distance)); // debugging
-				//list_branch_dist.push_back(float(nodes[nodes[i].connections[j].destindex].distance));
-
-				Vector3 a0 = nodes[i].p;
-				Vector3 a1 = nodes[nodes[i].connections[j].destindex].p;
-
-				// Use those if you want the points to be defined in the Lambert 93 coordinates
-				//Vector3 a0 = Vector3(nodes[i].p.x+870000.,nodes[i].p.y+6820000.,nodes[i].p.z);
-				//Vector3 a1 = Vector3(nodes[nodes[i].connections[j].destindex].p.x + 870000., nodes[nodes[i].connections[j].destindex].p.y + 6820000., nodes[nodes[i].connections[j].destindex].p.z);
-
-				Segment seg(a0, a1);
-				nghb_graph_line.push_back(seg);
-			}
-		}
-		std::vector<int> list_new_branch_id;
-		std::vector<int> used_id = { 0 };
-		std::vector<std::vector<int>> seen_br_id = { nodes[0].branch_id_ascend };
-
-		// Changing branch label for gocad visualization
-		for (int i = 0; i < nodes.size(); i++) {
-			for (int j = 0; j < nodes[i].connections.size(); j++) {
-				auto it = find(seen_br_id.begin(), seen_br_id.end(), nodes[nodes[i].connections[j].destindex].branch_id_ascend);
-
+				// set branch ids
 				if (it != seen_br_id.end()) { //id already found
-
 					ptrdiff_t pos = it - seen_br_id.begin();
-					list_new_branch_id.push_back(used_id[pos]);
-					list_new_branch_id.push_back(used_id[pos]);
+					start.branch_id = used_id[pos];
+					end.branch_id = used_id[pos];
 				}
 				else {	//id not found
 					seen_br_id.push_back(nodes[nodes[i].connections[j].destindex].branch_id_ascend);
-					list_new_branch_id.push_back(used_id[find(seen_br_id.begin(), seen_br_id.end(), nodes[i].branch_id_ascend) - seen_br_id.begin()]);
+					start.branch_id = used_id[find(seen_br_id.begin(), seen_br_id.end(), nodes[i].branch_id_ascend) - seen_br_id.begin()];
 					used_id.push_back(used_id.back() + 1);
-					list_new_branch_id.push_back(used_id.back());
+					end.branch_id = used_id.back();
 				}
+
+				result.add_segment(start, end);
 			}
 		}
 
-
-		Line full_line = nghb_graph_line;
-
-		int number_segs = full_line.get_nb_segs();
-		std::vector<std::string> property_names = { "cost","equivalent_radius", "branch_id","vadose_flag" };
-		std::vector<std::vector<std::vector<float>>> properties;
-
-		properties.resize(number_segs);
-		for (int segi = 0; segi < int(properties.size()); segi++) {
-			properties[segi].resize(4); // there is 4 properties in total
-		}
-		for (int n = 0; n < number_segs; n++) {
-			properties[n][0].push_back(list_cost[2 * n]);
-			properties[n][0].push_back(list_cost[2 * n + 1]);
-
-			properties[n][1].push_back(list_eq_radius[2 * n]);
-			properties[n][1].push_back(list_eq_radius[2 * n + 1]);
-
-			properties[n][2].push_back(list_new_branch_id[2 * n]);
-			properties[n][2].push_back(list_new_branch_id[2 * n + 1]);
-
-			properties[n][3].push_back(list_vadose[2 * n]);
-			properties[n][3].push_back(list_vadose[2 * n + 1]);
-
-			//properties[n][3].push_back(list_branch_dist[2 * n]); // for debugging
-			//properties[n][3].push_back(list_branch_dist[2 * n + 1]);
-
-		}
-		std::string full_name = network_name + "_karst.txt";
-		std::string full_dir_name = geologicalparams.directoryname + "/outputs";
-
-		save_line(full_name, full_dir_name, full_line, property_names, properties); // version with costs
-
+		return result;
 	}
 
 	// Method to populate distance matrix using Johnson's algorithm (which finds shortest distance between a pair of nodes in a graph)

--- a/KarstNSim/src/karstic_skeleton.cpp
+++ b/KarstNSim/src/karstic_skeleton.cpp
@@ -451,16 +451,16 @@ namespace KarstNSim {
 		return new_pts_and_idx;
 	}
 
-	float KarsticSkeleton::compute_wt_ratio(GraphOperations* graph, std::vector<Surface>* water_tables) {
+	float KarsticSkeleton::compute_wt_ratio(const GraphOperations& graph, const std::vector<Surface>& water_tables) {
 		float ratio = 0;
 
-		float dist_btw_wt = magnitude(water_tables->at(0).get_boundbox_max() - water_tables->at(1).get_boundbox_max());
+		float dist_btw_wt = magnitude(water_tables.at(0).get_boundbox_max() - water_tables.at(1).get_boundbox_max());
 
 
 		for (auto& node : nodes) {
 
-			float dist1 = graph->distsurf(node.p, &water_tables->at(0), std::numeric_limits<float>::infinity(), water_tables->at(0).get_centers_cloud());
-			float dist2 = graph->distsurf(node.p, &water_tables->at(1), std::numeric_limits<float>::infinity(), water_tables->at(1).get_centers_cloud());
+			float dist1 = graph.distsurf(node.p, water_tables[0], std::numeric_limits<float>::infinity(), water_tables[0].get_centers_cloud());
+			float dist2 = graph.distsurf(node.p, water_tables[1], std::numeric_limits<float>::infinity(), water_tables[1].get_centers_cloud());
 
 			if (dist1*dist1 + dist2 * dist2 < 0.95*dist_btw_wt*dist_btw_wt) {
 				ratio += 1;

--- a/KarstNSim/src/parse_inputs.cpp
+++ b/KarstNSim/src/parse_inputs.cpp
@@ -100,12 +100,8 @@ KarstNSim::ParamsSource ParseInputs::parse(const std::string& filename) {
 		std::cerr << "Error: " << std::strerror(errno) << std::endl;
 		throw std::runtime_error("Failed to open input file");
 	}
-
-	{
-		const std::string& p = filename;
-		const size_t pos = p.find_last_of("/\\");
-		params.simulation_input_dir = (pos == std::string::npos) ? std::string() : p.substr(0, pos);
-	}
+	// default: input files are located in the same directory as the main input file
+	params.simulation_input_dir = std::filesystem::absolute(filename).parent_path().string();
 
 	std::string line;
 	while (std::getline(inputFile, line)) {
@@ -130,6 +126,10 @@ KarstNSim::ParamsSource ParseInputs::parse(const std::string& filename) {
 		}
 		else if (paramType == "main_repository:") {
 			iss >> params.save_repository;
+		}
+		else if (paramType == "simulation_input_dir:") {
+			// allow changing the input directory from the default (same as main input file)
+			iss >> params.simulation_input_dir;
 		}
 
 		// General parameters

--- a/KarstNSim/src/parse_inputs.cpp
+++ b/KarstNSim/src/parse_inputs.cpp
@@ -610,6 +610,11 @@ KarstNSim::ParamsSource ParseInputs::parse(const std::string& filename) {
 		iss >> flag;
 		params.create_nghb_graph_property = parse_boolean(flag);
 		}
+		else if (paramType == "create_solved_connectivity_matrix:") {
+		std::string flag;
+		iss >> flag;
+		params.create_solved_connectivity_matrix = parse_boolean(flag);
+		}
 		else if (paramType == "create_grid:") {
 		std::string flag;
 		iss >> flag;

--- a/KarstNSim/src/run_code.cpp
+++ b/KarstNSim/src/run_code.cpp
@@ -227,9 +227,26 @@ namespace KarstNSim {
 
 			std::cout << "Parameters were prepared for simulation (" << init_time << " s)" << std::endl;
 
-			float time_needed = karst.run_simulation(parameters.sections_simulation_only, parameters.create_nghb_graph, parameters.create_nghb_graph_property, parameters.create_solved_connectivity_matrix, parameters.use_amplification,
+			auto result = karst.run_simulation(parameters.sections_simulation_only, parameters.create_nghb_graph, parameters.create_nghb_graph_property, parameters.create_solved_connectivity_matrix, parameters.use_amplification,
 				parameters.use_sampling_points, parameters.fraction_karst_perm, parameters.fraction_old_karst_perm, parameters.max_inception_surface_distance, &parameters.sampling_points, parameters.create_vset_sampling, parameters.use_density_property,
 				parameters.k_pts, parameters.propdensity, parameters.propikp);
+			
+			if (!result.has_value()) {
+				std::cout << "Simulation failed for seed " << used_seed << std::endl;
+				continue;
+			}
+			// save result to file
+			std::string full_name = sim_name_iter + "_karst.txt";
+			std::string full_dir_name = parameters.save_repository + "/outputs";
+			auto res_path = make_unique_filename(full_name, full_dir_name);
+			std::ofstream resfile(res_path);
+			if (resfile.is_open()) {
+				resfile << result->to_string();
+				resfile.close();
+			} else {
+				std::cout << "Failed to save karst network to file." << std::endl;
+			}
+
 			const clock_t time2 = clock();
 			float real_time_needed = float(time2 - begin_time) / CLOCKS_PER_SEC;
 

--- a/KarstNSim/src/run_code.cpp
+++ b/KarstNSim/src/run_code.cpp
@@ -132,14 +132,14 @@ namespace KarstNSim {
 
 			std::string sim_name_iter = parameters.karstic_network_name + "_" + std::to_string(i + parameters.selected_seed - 1);
 
-			KarsticNetwork karst(sim_name_iter, &parameters.domain, params, keypts, &parameters.surf_wat_table);
+			KarsticNetwork karst(sim_name_iter, parameters.domain, params, keypts, parameters.surf_wat_table);
 			karst.set_save_directory(parameters.save_repository);
 
-			karst.set_sinks(&parameters.sinks, parameters.propsinksindex, parameters.propsinksorder, parameters.use_sinks_radius, parameters.propsinksradius);
-			karst.set_springs(&parameters.springs, parameters.propspringsindex, parameters.allow_single_outlet_connection, parameters.use_springs_radius, parameters.propspringsradius, parameters.propspringssurfindex);
+			karst.set_sinks(parameters.sinks, parameters.propsinksindex, parameters.propsinksorder, parameters.use_sinks_radius, parameters.propsinksradius);
+			karst.set_springs(parameters.springs, parameters.propspringsindex, parameters.allow_single_outlet_connection, parameters.use_springs_radius, parameters.propspringsradius, parameters.propspringssurfindex);
 
 			if (parameters.use_waypoints) {
-				karst.set_waypoints(&parameters.waypoints, parameters.use_waypoints_radius, parameters.waypoints_radius, parameters.waypoints_impact_radius, parameters.waypoints_weight);
+				karst.set_waypoints(parameters.waypoints, parameters.use_waypoints_radius, parameters.waypoints_radius, parameters.waypoints_impact_radius, parameters.waypoints_weight);
 			}
 
 			if (parameters.use_deadend_points) {
@@ -147,14 +147,14 @@ namespace KarstNSim {
 			}
 
 			if (parameters.use_previous_networks) {
-				karst.set_previous_networks(&parameters.previous_networks);
+				karst.set_previous_networks(parameters.previous_networks);
 			}
 
 			if (parameters.use_karstification_potential) {
 				karst.set_karstification_potential_parameters(parameters.karstification_potential_weight);
 
 				if (parameters.use_ghostrocks) {
-					karst.set_ghost_rocks(parameters.domain, parameters.propikp, &parameters.alteration_lines,
+					karst.set_ghost_rocks(parameters.domain, parameters.propikp, parameters.alteration_lines,
 						parameters.interpolate_lines, parameters.ghostrock_max_vertical_size,
 						parameters.use_max_depth_constraint, parameters.ghost_rock_weight,
 						&parameters.max_depth_horizon, parameters.ghostrock_width);
@@ -166,25 +166,25 @@ namespace KarstNSim {
 			}
 
 			if (!parameters.sections_simulation_only) {
-				karst.set_wt_surfaces_sampling(sim_name_iter, &parameters.surf_wat_table, parameters.refine_surface_sampling);
+				karst.set_wt_surfaces_sampling(sim_name_iter, parameters.surf_wat_table, parameters.refine_surface_sampling);
 
 				if (parameters.add_inception_surfaces) {
 					if (!parameters.use_sampling_points) {
-						karst.set_inception_surfaces_sampling(sim_name_iter, &parameters.inception_surfaces,
+						karst.set_inception_surfaces_sampling(sim_name_iter, parameters.inception_surfaces,
 							parameters.refine_surface_sampling, parameters.create_vset_sampling);
 					}
-					karst.set_inception_horizons_parameters(&parameters.inception_surfaces,
+					karst.set_inception_horizons_parameters(parameters.inception_surfaces,
 						parameters.inception_surface_constraint_weight);
 				}
 				else {
 					karst.disable_inception_horizon();
 				}
 
-				karst.set_topo_surface(&parameters.topo_surface);
+				karst.set_topo_surface(parameters.topo_surface);
 
 				if (parameters.use_fracture_constraints) {
-					karst.set_fracture_constraint_parameters(&parameters.fracture_families_orientations,
-						&parameters.fracture_families_tolerance,
+					karst.set_fracture_constraint_parameters(parameters.fracture_families_orientations,
+						parameters.fracture_families_tolerance,
 						parameters.fracture_constraint_weight);
 				}
 				else {
@@ -192,7 +192,7 @@ namespace KarstNSim {
 				}
 
 				if (parameters.use_no_karst_spheres) {
-					karst.set_no_karst_spheres_parameters(&parameters.sphere_centers, parameters.sphere_radius);
+					karst.set_no_karst_spheres_parameters(parameters.sphere_centers, parameters.sphere_radius);
 				}
 
 				if (parameters.use_amplification) {
@@ -211,7 +211,7 @@ namespace KarstNSim {
 
 				karst.set_water_table_weight(parameters.water_table_constraint_weight_vadose, parameters.water_table_constraint_weight_phreatic);
 				karst.set_simulation_parameters(parameters.nghb_count, parameters.use_max_nghb_radius, parameters.nghb_radius, parameters.poisson_radius, parameters.gamma, parameters.multiply_costs, parameters.vadose_cohesion);
-				karst.read_connectivity_matrix(parameters.simulation_input_dir, &parameters.sinks, &parameters.springs);
+				karst.read_connectivity_matrix(parameters.simulation_input_dir, parameters.sinks, parameters.springs);
 			}
 
 			if (parameters.simulate_sections) {
@@ -228,7 +228,7 @@ namespace KarstNSim {
 			std::cout << "Parameters were prepared for simulation (" << init_time << " s)" << std::endl;
 
 			auto result = karst.run_simulation(parameters.sections_simulation_only, parameters.create_nghb_graph, parameters.create_nghb_graph_property, parameters.create_solved_connectivity_matrix, parameters.use_amplification,
-				parameters.use_sampling_points, parameters.fraction_karst_perm, parameters.fraction_old_karst_perm, parameters.max_inception_surface_distance, &parameters.sampling_points, parameters.create_vset_sampling, parameters.use_density_property,
+				parameters.use_sampling_points, parameters.fraction_karst_perm, parameters.fraction_old_karst_perm, parameters.max_inception_surface_distance, parameters.sampling_points, parameters.create_vset_sampling, parameters.use_density_property,
 				parameters.k_pts, parameters.propdensity, parameters.propikp);
 			
 			if (!result.has_value()) {
@@ -303,7 +303,7 @@ namespace KarstNSim {
 			std::string sim_name_iter = parameters.karstic_network_name + "_" + std::to_string(i + parameters.selected_seed - 1);
 
 
-			KarsticNetwork karst(sim_name_iter, &parameters.domain, params, keypts, &parameters.surf_wat_table);
+			KarsticNetwork karst(sim_name_iter, parameters.domain, params, keypts, parameters.surf_wat_table);
 
 			karst.set_save_directory(parameters.save_repository);
 
@@ -325,15 +325,17 @@ namespace KarstNSim {
 					throw std::runtime_error("Waypoints enabled but 'impact_radius' is missing or mismatched.");
 				}
 
-				karst.set_waypoints(&parameters.waypoints,
+				karst.set_waypoints(
+					parameters.waypoints,
 					can_use_radius,
 					parameters.waypoints_radius,
 					parameters.waypoints_impact_radius,
-					parameters.waypoints_weight);
+					parameters.waypoints_weight
+				);
 			}
 
 			if (parameters.use_previous_networks) {
-				karst.set_previous_networks(&parameters.previous_networks);
+				karst.set_previous_networks(parameters.previous_networks);
 			}
 
 			karst.set_geostat_params(parameters.geostat_params);
@@ -348,7 +350,7 @@ namespace KarstNSim {
 			std::cout << "Parameters were prepared for simulation (" << init_time << " s)" << std::endl;
 			std::cout << "Simulation of properties..." << std::endl;
 
-			karst.run_simulation_properties(skel, &parameters.alteration_lines, parameters.use_ghostrocks, parameters.ghostrock_max_vertical_size, parameters.use_max_depth_constraint, &parameters.max_depth_horizon, parameters.ghostrock_width);
+			karst.run_simulation_properties(skel, parameters.alteration_lines, parameters.use_ghostrocks, parameters.ghostrock_max_vertical_size, parameters.use_max_depth_constraint, parameters.max_depth_horizon, parameters.ghostrock_width);
 			const clock_t time2 = clock();
 			float real_time_needed = float(time2 - begin_time) / CLOCKS_PER_SEC;
 

--- a/KarstNSim/src/run_code.cpp
+++ b/KarstNSim/src/run_code.cpp
@@ -227,7 +227,7 @@ namespace KarstNSim {
 
 			std::cout << "Parameters were prepared for simulation (" << init_time << " s)" << std::endl;
 
-			float time_needed = karst.run_simulation(parameters.sections_simulation_only, parameters.create_nghb_graph, parameters.create_nghb_graph_property, parameters.use_amplification,
+			float time_needed = karst.run_simulation(parameters.sections_simulation_only, parameters.create_nghb_graph, parameters.create_nghb_graph_property, parameters.create_solved_connectivity_matrix, parameters.use_amplification,
 				parameters.use_sampling_points, parameters.fraction_karst_perm, parameters.fraction_old_karst_perm, parameters.max_inception_surface_distance, &parameters.sampling_points, parameters.create_vset_sampling, parameters.use_density_property,
 				parameters.k_pts, parameters.propdensity, parameters.propikp);
 			const clock_t time2 = clock();

--- a/KarstNSim/src/surface_sampling.cpp
+++ b/KarstNSim/src/surface_sampling.cpp
@@ -23,13 +23,13 @@ namespace {
 using MySet = std::unordered_set<Vector3, myhash>;
 
 namespace KarstNSim {
-	void surface_sampling::multiple_surface_sampling(std::string directoryname, std::string network_name, Box* box, std::vector<Surface>* surface, std::vector<Vector3>& points, const int refine_surface_sampling, const bool create_vset_sampling)
+	void surface_sampling::multiple_surface_sampling(std::string directoryname, std::string network_name, const Box& box, const std::vector<Surface>& surface, std::vector<Vector3>& points, const int refine_surface_sampling, const bool create_vset_sampling)
 	{
 		// we iterate on the surfaces
 		MySet res; // unordered sets don't allow for duplicates, which is perfect for our usage here
-		for (int k = 0; k < surface->size(); k++) {
+		for (int k = 0; k < surface.size(); k++) {
 			// we iterate on the triangles of the surface
-			Surface surfk = surface->at(k);
+			Surface surfk = surface.at(k);
 			for (int j = 0; j < surfk.get_nb_trgls(); j++) {
 				bool allow_refinement = false;
 				std::vector<Vector3> trgl_pts;
@@ -40,14 +40,14 @@ namespace KarstNSim {
 					Vector3 p = surfk.get_node(trgl.point(i));
 					trgl_pts.push_back(p);
 					// continue only if the point is in the grid
-					if (box->contains(p) && !allow_refinement) {
+					if (box.contains(p) && !allow_refinement) {
 						allow_refinement = true;
 					}
 				}
 
 				if (allow_refinement && refine_surface_sampling != -1) {
 					for (int i = 0; i < 3; i++) {
-						if (box->contains(trgl_pts[i])) {
+						if (box.contains(trgl_pts[i])) {
 							res.insert(trgl_pts[i]);
 						}
 					}
@@ -75,13 +75,13 @@ namespace KarstNSim {
 							Vector3 u = (a + b) / 2;
 							Vector3 v = (c + b) / 2;
 							Vector3 w = (a + c) / 2;
-							if (box->contains(u)) {
+							if (box.contains(u)) {
 								res.insert(u);
 							}
-							if (box->contains(v)) {
+							if (box.contains(v)) {
 								res.insert(v);
 							}
-							if (box->contains(w)) {
+							if (box.contains(w)) {
 								res.insert(w);
 							}
 							new_tri.push_back(std::vector<Vector3>({ a,u,w }));

--- a/KarstNSim/src/write_files.cpp
+++ b/KarstNSim/src/write_files.cpp
@@ -31,19 +31,13 @@ namespace KarstNSim {
 		}
 	}
 
-	// Function to check if a file exists
-	static bool file_exists(const std::string& file_path) {
-		std::error_code ec;
-		return std::filesystem::exists(file_path, ec) && !ec;
-	}
-
 	// Generate a unique filename by appending (0), (1), etc. if needed
 	std::filesystem::path make_unique_filename(const std::string& base_filename, const std::string& save_directory) {
 		std::filesystem::path dirPath(save_directory);
 		std::filesystem::path filePath(base_filename);
 		std::filesystem::path fullPath = dirPath / filePath;
-		
-		if (!file_exists(fullPath)) {
+
+		if (!std::filesystem::exists(fullPath)) {
 			return fullPath;  // Already unique
 		}
 
@@ -56,7 +50,7 @@ namespace KarstNSim {
 			std::string uniqueFilename = baseName + "(" + std::to_string(copyIndex) + ")" + extension;
 			uniquePath = dirPath / uniqueFilename;
 			copyIndex++;
-		} while (file_exists(uniquePath));
+		} while (std::filesystem::exists(uniquePath));
 		
 		return uniquePath;
 	}

--- a/KarstNSim/src/write_files.cpp
+++ b/KarstNSim/src/write_files.cpp
@@ -9,148 +9,68 @@ If you use this code, please cite : Gouy et al., 2024, Journal of Hydrology.
 ***************************************************************/
 
 #include "KarstNSim/write_files.h"
-#include <cerrno>
-#include <cstring>
+#include <filesystem>
 
 namespace KarstNSim {
 
-	bool directory_exists(const std::string& directory) {
-		struct stat info;
-		if (stat(directory.c_str(), &info) != 0) {
-			return false;
-		}
-		return (info.st_mode & S_IFDIR) != 0;
+	static bool directory_exists(const std::string& directory) {
+		std::error_code ec;
+		return std::filesystem::is_directory(directory, ec) && !ec;
 	}
 
-	void create_directory(const std::string& directory) {
-#ifdef _WIN32
-		int res = _mkdir(directory.c_str());
-#else
-		int res = mkdir(directory.c_str(), 0777);
-#endif
-		if (res != 0) {
-			std::cerr << "Error creating directory: " << directory << " (" << strerror(errno) << ")" << std::endl;
+	static void create_directory(const std::string& directory) {
+		std::error_code ec;
+		if (!std::filesystem::create_directories(directory, ec) && ec) {
+			std::cerr << "Error creating directory: " << directory << " (" << ec.message() << ")" << std::endl;
+		}
+	}
+
+	static void ensure_directory_exists(const std::string& directory) {
+		if (!directory_exists(directory)) {
+			create_directory(directory);
 		}
 	}
 
 	// Function to check if a file exists
-	bool file_exists(const std::string& file_path) {
-		struct stat buffer;
-		return (stat(file_path.c_str(), &buffer) == 0);
+	static bool file_exists(const std::string& file_path) {
+		std::error_code ec;
+		return std::filesystem::exists(file_path, ec) && !ec;
 	}
 
-	// Function to modify the file name by reference to ensure uniqueness
-	void make_unique_filename(std::string& fileName, const std::string& saveDirectory) {
-		std::string baseName = fileName;
-		std::string extension = "";
-
-		// Find the last dot to separate the file name and extension
-		size_t dotPos = fileName.find_last_of('.');
-		if (dotPos != std::string::npos) {
-			baseName = fileName.substr(0, dotPos);
-			extension = fileName.substr(dotPos);
+	// Generate a unique filename by appending (0), (1), etc. if needed
+	std::filesystem::path make_unique_filename(const std::string& base_filename, const std::string& save_directory) {
+		std::filesystem::path dirPath(save_directory);
+		std::filesystem::path filePath(base_filename);
+		std::filesystem::path fullPath = dirPath / filePath;
+		
+		if (!file_exists(fullPath)) {
+			return fullPath;  // Already unique
 		}
+
+		std::string baseName = filePath.stem().string();
+		std::string extension = filePath.extension().string();
 
 		int copyIndex = 0;
-
-		// Keep modifying the file name until it's unique
-		while (file_exists(saveDirectory + '/' + fileName)) {
-			std::ostringstream oss;
-			oss << baseName << '(' << copyIndex << ')' << extension;
-			fileName = oss.str();
+		std::filesystem::path uniquePath;
+		do {
+			std::string uniqueFilename = baseName + "(" + std::to_string(copyIndex) + ")" + extension;
+			uniquePath = dirPath / uniqueFilename;
 			copyIndex++;
-		}
-	}
-
-	void make_unique_filename(std::string& file_name, const std::string& save_directory, Vector3 u, std::vector<std::string> property_names, std::vector<float> properties)
-	{
-
-		// Check if the save directory exists, if not, create it
-		if (!directory_exists(save_directory)) {
-			create_directory(save_directory);
-		}
-
-		// Ensure the file name is unique (modifies file_name by reference if needed)
-		make_unique_filename(file_name, save_directory);
-
-		std::ofstream out;
-		out.open(save_directory + '/' + file_name);
-		if (out.is_open() == false)
-		{
-			std::cout << "Cannot save skeleton to file (nodes): " << file_name << std::endl;
-			return;
-		}
-
-		out << "Index	X	Y	Z";
-		for (int j = 0; j < property_names.size(); j++) { // iterate on properties (if any)
-			out << "	" << property_names[j]; // get name of property j
-		}
-		out << "\n";
-
-		out << 1 << "	" << u[0] << "	" << u[1] << "	" << u[2];
-		if (properties.size()) {
-			for (int j = 0; j < int(properties.size()); j++) { // iterate on properties (if any)
-				out << "	" << std::fixed << std::setprecision(10) << properties[j];
-			}
-			out << "\n";
-		}
-		out.flush();
-		out.close();
-	}
-
-	// Adjust the file name to the "last" existing version
-	void adjust_file_name_to_last(std::string& file_name, const std::string& save_directory) {
-		std::string base_name = file_name;
-		std::string extension = "";
-
-		// Separate the file name and extension
-		size_t dot_pos = file_name.find_last_of('.');
-		if (dot_pos != std::string::npos) {
-			base_name = file_name.substr(0, dot_pos);
-			extension = file_name.substr(dot_pos);
-		}
-
-		int copy_index = 0;
-		std::string candidate_name = file_name;
-		std::string candidate_name_new = file_name;
-		std::ostringstream oss;
-		std::string ossstr = candidate_name;
-		oss << file_name;
-
-		// Search for the last available file name in the sequence
-		while (file_exists(save_directory + '/' + candidate_name_new)) {
-			candidate_name = ossstr;
-			std::ostringstream oss;
-			oss << base_name << '(' << copy_index << ')' << extension;
-			ossstr = oss.str();
-			candidate_name_new = ossstr;
-			copy_index++;
-		}
-
-		//// Adjust file_name to the "last existing" version
-		//if (copy_index > 0) {
-		//	std::ostringstream oss;
-		//	oss << base_name << '(' << (copy_index - 1) << ')' << extension;
-		//	
-		//}
-		file_name = candidate_name;
+		} while (file_exists(uniquePath));
+		
+		return uniquePath;
 	}
 
 	// Save the point data to a unique file
-	void save_point(std::string& file_name, const std::string& save_directory, Vector3 u, std::vector<std::string> property_names, std::vector<float> properties) {
+	void save_point(const std::string& file_name, const std::string& save_directory, Vector3 u, std::vector<std::string> property_names, std::vector<float> properties) {
 
-		// Check if the save directory exists, if not, create it
-		if (!directory_exists(save_directory)) {
-			create_directory(save_directory);
-		}
+		ensure_directory_exists(save_directory);
 
-		// Ensure the file name is unique (modifies file_name by reference)
-		make_unique_filename(file_name, save_directory);
-
-		std::ofstream out;
-		out.open(save_directory + '/' + file_name);
-		if (out.is_open() == false) {
-			std::cout << "Cannot save skeleton to file (nodes): " << file_name << std::endl;
+		// Generate a unique file path
+		std::filesystem::path filePath = make_unique_filename(file_name, save_directory);
+		std::ofstream out(filePath);
+		if (!out.is_open()) {
+			std::cout << "Cannot save skeleton to file (nodes): " << filePath.filename() << std::endl;
 			return;
 		}
 
@@ -171,25 +91,21 @@ namespace KarstNSim {
 		out.close();
 	}
 
-	void save_surface(std::string& file_name, const std::string& save_directory, Surface s, std::vector<std::string> property_names, std::vector<std::vector<float>> properties)
+	void save_surface(const std::string& file_name, const std::string& save_directory, Surface s, std::vector<std::string> property_names, std::vector<std::vector<float>> properties)
 	{
 
-		// Check if the save directory exists, if not, create it
-		if (!directory_exists(save_directory)) {
-			create_directory(save_directory);
-		}
+		ensure_directory_exists(save_directory);
 
-		// Ensure the file name is unique (modifies file_name by reference if needed)
-		make_unique_filename(file_name, save_directory);
+		// Generate a unique file path
+		std::filesystem::path filePath = make_unique_filename(file_name, save_directory);
 
 		int nb_pts = s.get_nb_pts();
 		int nb_trgls = s.get_nb_trgls();
 
-		std::ofstream out;
-		out.open(save_directory + '/' + file_name);
-		if (out.is_open() == false)
+		std::ofstream out(filePath);
+		if (!out.is_open())
 		{
-			std::cout << "Cannot save skeleton to file (nodes): " << file_name << std::endl;
+			std::cout << "Cannot save skeleton to file (nodes): " << filePath.filename() << std::endl;
 			return;
 		}
 
@@ -220,23 +136,19 @@ namespace KarstNSim {
 		out.close();
 	}
 
-	void save_pointset(std::string& file_name, const std::string& save_directory, std::vector<Vector3> pset, std::vector<std::string> property_names, std::vector<std::vector<float>> properties)
+	void save_pointset(const std::string& file_name, const std::string& save_directory, std::vector<Vector3> pset, std::vector<std::string> property_names, std::vector<std::vector<float>> properties)
 	{
 
-		// Check if the save directory exists, if not, create it
-		if (!directory_exists(save_directory)) {
-			create_directory(save_directory);
-		}
+		ensure_directory_exists(save_directory);
 
-		// Ensure the file name is unique (modifies file_name by reference if needed)
-		make_unique_filename(file_name, save_directory);
+		// Generate a unique file path
+		std::filesystem::path filePath = make_unique_filename(file_name, save_directory);
 
 		int nb_pts = int(pset.size());
-		std::ofstream out;
-		out.open(save_directory + '/' + file_name);
-		if (out.is_open() == false)
+		std::ofstream out(filePath);
+		if (!out.is_open())
 		{
-			std::cout << "Cannot save skeleton to file (nodes): " << file_name << std::endl;
+			std::cout << "Cannot save skeleton to file (nodes): " << filePath.filename() << std::endl;
 			return;
 		}
 		out << "Index	X	Y	Z";
@@ -260,24 +172,20 @@ namespace KarstNSim {
 		out.close();
 	}
 
-	void save_line(std::string& file_name, const std::string& save_directory, Line pline, std::vector<std::string> property_names, std::vector<std::vector<std::vector<float>>> properties)
+	void save_line(const std::string& file_name, const std::string& save_directory, Line pline, std::vector<std::string> property_names, std::vector<std::vector<std::vector<float>>> properties)
 	{
 
-		// Check if the save directory exists, if not, create it
-		if (!directory_exists(save_directory)) {
-			create_directory(save_directory);
-		}
+		ensure_directory_exists(save_directory);
 
-		// Ensure the file name is unique (modifies file_name by reference if needed)
-		make_unique_filename(file_name, save_directory);
+		// Generate a unique file path
+		std::filesystem::path filePath = make_unique_filename(file_name, save_directory);
 
 		int nb_segs = pline.get_nb_segs();
 
-		std::ofstream out;
-		out.open(save_directory + '/' + file_name);
-		if (out.is_open() == false)
+		std::ofstream out(filePath);
+		if (!out.is_open())
 		{
-			std::cout << "Cannot save skeleton to file (nodes): " << file_name << std::endl;
+			std::cout << "Cannot save skeleton to file (nodes): " << filePath.filename() << std::endl;
 			return;
 		}
 
@@ -312,21 +220,17 @@ namespace KarstNSim {
 		out.close();
 	}
 
-	void save_connectivity_matrix(std::string& file_name, const std::string& save_directory, Array2D<int> matrix) {
+	void save_connectivity_matrix(const std::string& file_name, const std::string& save_directory, Array2D<int> matrix) {
 
-		// Check if the save directory exists, if not, create it
-		if (!directory_exists(save_directory)) {
-			create_directory(save_directory);
-		}
+		ensure_directory_exists(save_directory);
 
-		// Ensure the file name is unique (modifies file_name by reference if needed)
-		make_unique_filename(file_name, save_directory);
+		// Generate a unique file path
+		std::filesystem::path filePath = make_unique_filename(file_name, save_directory);
 
-		std::ofstream out;
-		out.open(save_directory + '/' + file_name);
-		if (out.is_open() == false)
+		std::ofstream out(filePath);
+		if (!out.is_open())
 		{
-			std::cout << "Cannot save connectivity matrix " << file_name << std::endl;
+			std::cout << "Cannot save connectivity matrix " << filePath.filename() << std::endl;
 			return;
 		}
 
@@ -346,22 +250,18 @@ namespace KarstNSim {
 
 	}
 
-	void save_box(std::string& file_name, const std::string& save_directory, Box box, std::vector<std::string> property_names, std::vector<std::vector<float>> properties)
+	void save_box(const std::string& file_name, const std::string& save_directory, Box box, std::vector<std::string> property_names, std::vector<std::vector<float>> properties)
 	{
 
-		// Check if the save directory exists, if not, create it
-		if (!directory_exists(save_directory)) {
-			create_directory(save_directory);
-		}
+		ensure_directory_exists(save_directory);
 
-		// Ensure the file name is unique (modifies file_name by reference if needed)
-		make_unique_filename(file_name, save_directory);
+		// Generate a unique file path
+		std::filesystem::path filePath = make_unique_filename(file_name, save_directory);
 
-		std::ofstream out;
-		out.open(save_directory + '/' + file_name);
-		if (out.is_open() == false)
+		std::ofstream out(filePath);
+		if (!out.is_open())
 		{
-			std::cout << "Cannot save skeleton to file (nodes): " << file_name << std::endl;
+			std::cout << "Cannot save skeleton to file (nodes): " << filePath.filename() << std::endl;
 			return;
 		}
 		int nb_prop = int(property_names.size());

--- a/config_reference.md
+++ b/config_reference.md
@@ -26,6 +26,7 @@ Unless stated otherwise, distances/lengths are in the same units as your model c
 ### `domain: <path>`
 - **Type**: `path` (text voxet/box description with density property and optionally IKP property)
 - **What it does**: Defines the 3D domain (origin, axes, grid size) used for sampling and grid-based properties (density and IKP (Intrinsic Karstification Potential), the second being optional). Density values range from 0 to 1 both excluded, and IKP from 0 to 1 both included. Any negative value is considered a NDV, but -99999 is the default NDV for both.
+- **Indexing reminder**: KarstNSim expects grid properties (`density`, `IKP`, etc.) to be flattened with the **u axis as the fastest varying index**, followed by **v**, then **w**. In other words, the linear index must be computed as `idx = u + nu * v + nu * nv * w` where `0 ≤ u < nu`, `0 ≤ v < nv`, `0 ≤ w < nw`. When exporting or building voxets from external tools, make sure the serialization order matches this convention; mismatches will map sampled points to the wrong cells.
 
 ### `selected_seed: <int>`
 - **Type**: `int` (≥ 0)

--- a/simulation_times.txt
+++ b/simulation_times.txt
@@ -1,9 +1,0 @@
-example: 157.016 s for seed 1
-example: 101.765 s for seed 1
-example: 98.453 s for seed 1
-example: 154.918 s for seed 1
-base: 92.759 s for seed 1
-base: 99.308 s for seed 1
-polyphasic: 37.411 s for seed 1
-polyphasic: 105.655 s for seed 1
-section_gen: 0.324 s for seed 1


### PR DESCRIPTION
This PR contains a bunch of code changes to make the Python wrapping of this library easier, notably by being able to turn off all files writing.

 - Add a flag to control writing of the "solved" connectivity matrix
 - KarsticNetwork::run_simulation now returns an object containing the resulting network instead of directly writing it to a file
 - Change raw pointers to const references everywhere possible

Some other changes that I took the opportunity to do as well:

 - Bump C++ standard to C++17 to unlock std::filesystem API
 - Use filesystem API to rewrite a portion of the write_files module to ensure it works the same way as before with the new result object

The CLI program works exactly the same as before, writing the result after retrieving it. I merged the 1.3 changes in already too. Thanks a lot for the changes, especially the config reference which will be very useful!

This is normally the last PR I'll do for a while, as the Python interop is now working well. 